### PR TITLE
Amulet mat fix

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -1730,7 +1730,7 @@ int how;
                     discover_object(otmp->otyp, TRUE, FALSE);
                     otmp->known = 1;  /* for fake amulets */
                     otmp->dknown = 1; /* seen it (blindness fix) */
-                    otmp->material = val->list[i].mat;
+                    otmp->material = mat;
                     if (has_oname(otmp))
                         free_oname(otmp);
                     otmp->quan = count;

--- a/src/end.c
+++ b/src/end.c
@@ -24,14 +24,42 @@
 #define FIRST_AMULET AMULET_OF_ESP
 #define LAST_AMULET AMULET_OF_YENDOR
 
+/* Same values as in shk.c */
+STATIC_DCL
+const int matprices[] = {
+     0,
+     1, /* LIQUID */
+     1, /* WAX */
+     1, /* VEGGY */
+     3, /* FLESH */
+     2, /* PAPER */
+     3, /* CLOTH */
+     5, /* LEATHER */
+     8, /* WOOD */
+    20, /* BONE */
+   200, /* DRAGON_HIDE - DSM to scale mail */
+    10, /* IRON */
+    10, /* METAL */
+    10, /* COPPER */
+    30, /* SILVER */
+    60, /* GOLD */
+    80, /* PLATINUM */
+    50, /* MITHRIL - mithril-coat to regular chain mail */
+    10, /* PLASTIC */
+    20, /* GLASS */
+   500, /* GEMSTONE */
+    10  /* MINERAL */
+};
+
 struct valuable_data {
     long count;
     int typ;
+    int mat;
 };
 
 static struct valuable_data
     gems[LAST_GEM + 1 - FIRST_GEM + 1], /* 1 extra for glass */
-    amulets[LAST_AMULET + 1 - FIRST_AMULET];
+    amulets[(LAST_AMULET + 1 - FIRST_AMULET) * NUM_MATERIAL_TYPES];
 
 static struct val_list {
     struct valuable_data *list;
@@ -1028,10 +1056,12 @@ struct obj *list; /* inventory or container contents */
         } else if (obj->oartifact) {
             continue;
         } else if (obj->oclass == AMULET_CLASS) {
-            i = obj->otyp - FIRST_AMULET;
+            i = ((obj->otyp - FIRST_AMULET) * NUM_MATERIAL_TYPES)
+                + obj->material;
             if (!amulets[i].count) {
                 amulets[i].count = obj->quan;
                 amulets[i].typ = obj->otyp;
+                amulets[i].mat = obj->material;
             } else
                 amulets[i].count += obj->quan; /* always adds one */
         } else if (obj->oclass == GEM_CLASS && obj->otyp < LUCKSTONE) {
@@ -1039,6 +1069,7 @@ struct obj *list; /* inventory or container contents */
             if (!gems[i].count) {
                 gems[i].count = obj->quan;
                 gems[i].typ = obj->otyp;
+                gems[i].mat = obj->material;
             } else
                 gems[i].count += obj->quan;
         }
@@ -1636,7 +1667,9 @@ int how;
             for (i = 0; i < val->size; i++)
                 if (val->list[i].count != 0L) {
                     tmp = val->list[i].count
-                          * (long) objects[val->list[i].typ].oc_cost;
+                          * (long) objects[val->list[i].typ].oc_cost
+                          * (long) matprices[val->list[i].mat]
+                          / (long) matprices[objects[val->list[i].typ].oc_material];
                     nowrap_add(u.urexp, tmp);
                 }
 
@@ -1688,6 +1721,7 @@ int how;
             for (i = 0; i < val->size && !done_stopprint; i++) {
                 int typ = val->list[i].typ;
                 long count = val->list[i].count;
+                int mat = val->list[i].mat;
 
                 if (count == 0L)
                     continue;
@@ -1696,11 +1730,15 @@ int how;
                     discover_object(otmp->otyp, TRUE, FALSE);
                     otmp->known = 1;  /* for fake amulets */
                     otmp->dknown = 1; /* seen it (blindness fix) */
+                    otmp->material = val->list[i].mat;
                     if (has_oname(otmp))
                         free_oname(otmp);
                     otmp->quan = count;
                     Sprintf(pbuf, "%8ld %s (worth %ld %s),", count,
-                            xname(otmp), count * (long) objects[typ].oc_cost,
+                            xname(otmp), count
+                                * (long) objects[typ].oc_cost
+                                * (long) matprices[mat]
+                                / (long) matprices[objects[typ].oc_material],
                             currency(2L));
                     obfree(otmp, (struct obj *) 0);
                 } else {


### PR DESCRIPTION
I noticed some dumplogs (e.g. [mine](https://au.hardfought.org/userdata/o/ogmobot/evilhack/dumplog/1563082061.evil.txt) and [ShivanHunter's](https://www.hardfought.org/userdata/S/ShivanHunter/evilhack/dumplog/1565342885.evil.txt)) weren't very accurate about amulet materials when listing valuables at the end of the file. For instance, my `blessed mithril amulet of unchanging` became `1 gold amulet of unchanging`. This patch keeps track of amulet type and material separately to fix that. (Downside: instead of `8 amulets of life saving`(!), ShivanHunter would have had `3 silver amulets of life saving, 2 copper amulets of life saving, 2 amulets of life saving, 1 gold amulet of life saving` -- a bit more of a mouthful.)
This patch also changes the price of the amulets based on their materials. Instead of all being worth 150zm, their value is scaled up by the matprices from shk.c (so silver amulets are worth 450zm, for example).