### PR TITLE
More appropriate non-artifact sacrifice gifts

### DIFF
--- a/src/pray.c
+++ b/src/pray.c
@@ -1444,6 +1444,10 @@ register struct obj *otmp;
     exercise(A_WIS, TRUE);
 }
 
+struct inv_sub { short race_pm, item_otyp, subs_otyp; };
+extern struct inv_sub inv_subs[];
+
+
 int
 dosacrifice()
 {
@@ -1904,7 +1908,7 @@ dosacrifice()
             }
         } else {
             int nartifacts = nartifact_exist();
-	    int nchance = u.ulevel + 6;
+	        int nchance = u.ulevel + 6;
             boolean primary_casters, primary_casters_priest;
 
             /* Primary casting roles */
@@ -1913,164 +1917,292 @@ dosacrifice()
 
             /* you were already in pretty good standing
              *
-	     * The player can gain an artifact;
-	     * The chance goes down as the number of artifacts goes up.
-             *
-             * From SporkHack (heavily modified):
-	     * The player can also get handed just a plain old hunk of weaponry
-	     * or piece of armor, but it will be blessed, +3 to +5, fire/rustproof, and
-	     * if it's a weapon, it'll be in one of the player's available skill
-	     * slots. The lower level you are, the more likely it is that you'll
-	     * get a hunk of ordinary junk rather than an artifact.
-             *
-	     * Note that no artifact is guaranteed; it's still subject to the
-             * chances of generating one of those in the first place. These are
-	     * just the chances that an artifact will even be considered as a gift.
-	     *
-	     * level  4: 10% chance  level  9: 20% chance  level 12: 30% chance
-	     * level 14: 40% chance  level 17: 50% chance  level 19: 60% chance
-	     * level 21: 70% chance  level 23: 80% chance  level 24: 90% chance
-	     * level 26: 100% chance
-	     */
+			 * The player can gain an artifact;
+			 * The chance goes down as the number of artifacts goes up.
+				 *
+				 * From SporkHack (heavily modified):
+			 * The player can also get handed just a plain old hunk of weaponry
+			 * or piece of armor, but it will be blessed, +3 to +5, fire/rustproof, and
+			 * if it's a weapon, it'll be in one of the player's available skill
+			 * slots. The lower level you are, the more likely it is that you'll
+			 * get a hunk of ordinary junk rather than an artifact.
+				 *
+			 * Note that no artifact is guaranteed; it's still subject to the
+				 * chances of generating one of those in the first place. These are
+			 * just the chances that an artifact will even be considered as a gift.
+			 *
+			 * level  4: 10% chance  level  9: 20% chance  level 12: 30% chance
+			 * level 14: 40% chance  level 17: 50% chance  level 19: 60% chance
+			 * level 21: 70% chance  level 23: 80% chance  level 24: 90% chance
+			 * level 26: 100% chance
+			 */
+			if (rn2(10) >= (int)((nchance * nchance) / 100)) {
+				if (u.uluck >= 0 && !rn2(6 + (2 * u.ugifts))) {
+					int typ, ncount = 0;
+					if (rn2(2)) { // Making a weapon
+						do {
+							/* Don't give unicorn horns or anything the player's restricted in
+							 * Lets also try to dish out suitable gear based on the player's role */
+							if (primary_casters) {
+								typ = rn2(2) ? rnd_class(DAGGER, ATHAME) : rnd_class(MACE, FLAIL);
+							} else if (primary_casters_priest) {
+								typ = rnd_class(MACE, FLAIL);
+							} else if (Role_if(PM_MONK)) {
+								typ = rnd_class(QUARTERSTAFF, STAFF_OF_WAR);
+							} else {
+								typ = rnd_class(SPEAR, KATANA);
+							}
+				
+							// apply starting inventory subs - so we'll get racial gear if possible
+							if (urace.malenum != PM_HUMAN) {
+								for (int i = 0; inv_subs[i].race_pm != NON_PM; ++i){
+									if (inv_subs[i].race_pm == urace.malenum && typ == inv_subs[i].item_otyp) {
+										typ = inv_subs[i].subs_otyp;
+										break;
+									}
+								}
+							}
+				
+							/*
+							if (objects[typ].oc_material == IRON && Race_if(PM_ELF))
+								typ = 0;
+							else if (objects[typ].oc_material == MITHRIL && Race_if(PM_ORC))
+								typ = 0;
+							*/ 
+							// The issue here is it blocks elves from getting basically 
+							// anything, since most (non-elven) weapons are base mat iron...
+								
+							// if we have the WRONG race, then let's not do that
+							otmp = mksobj(typ, FALSE, FALSE);
+							if (is_elven_obj(otmp) && !Race_if(PM_ELF)){
+								typ = 0;
+							} else if (is_orcish_obj(otmp) && !Race_if(PM_ORC)){
+								typ = 0;
+							} else if (is_dwarvish_obj(otmp) && !Race_if(PM_DWARF)){
+								typ = 0;
+							}
+							
+							otmp = (struct obj *) 0;
+							
+							if (typ && !P_RESTRICTED(objects[typ].oc_skill))
+								break;
+						} while (ncount++ < 1000);
 
-            if (rn2(10) >= (nchance * nchance) / 100) {
-		if (u.uluck >= 0 && !rn2(6 + (2 * u.ugifts))) {
-		    int typ, ncount = 0;
-		    if (rn2(2)) {
-		    /* Don't give unicorn horns or anything the player's restricted in
-                     * Lets also try to dish out suitable gear based on the player's role */
-		        do {
-                            if (primary_casters) {
-                                typ = rn2(2) ? rnd_class(DAGGER, ATHAME)
-                                             : rnd_class(MACE, FLAIL);
-                            } else if (primary_casters_priest) {
-                                typ = rnd_class(MACE, FLAIL);
-                            } else if (Role_if(PM_MONK)) {
-                                typ = rnd_class(QUARTERSTAFF, STAFF_OF_WAR);
-                            } else {
-                                typ = rnd_class(SPEAR, KATANA);
-                            }
-		        } while (ncount++ < 500 && typ && P_RESTRICTED(objects[typ].oc_skill));
-		            if (ncount > 499) {
-                                return 1;
-                            }
-		        } else if (primary_casters || primary_casters_priest) {
-                            if (rn2(3)) {
-		                typ = rn2(2) ? rnd_class(ELVEN_HELM, HELM_OF_TELEPATHY)
-                                             : rnd_class(GLOVES, LEVITATION_BOOTS);
-                            } else {
-                                int sp_no, trycnt = u.ulevel + 1;
+						if (ncount > 999) {
+							debugpline0("Ran out of tries making weapon");
+							return 1;
+						}
+					} else if ((primary_casters || primary_casters_priest) && !rn2(3)) { // Making a spellbook
+						int sp_no, trycnt = u.ulevel + 1;
 
-                                otmp = mkobj(SPBOOK_CLASS, TRUE);
-                                while (--trycnt > 0) {
-                                    if (otmp->otyp != SPE_BLANK_PAPER) {
-                                        for (sp_no = 0; sp_no < MAXSPELL; sp_no++)
-                                            if (spl_book[sp_no].sp_id == otmp->otyp)
-                                                break;
-                                        if (sp_no == MAXSPELL
-                                            && !P_RESTRICTED(spell_skilltype(otmp->otyp)))
-                                            break; /* usable, but not yet known */
-                                    } else {
-                                        if (!objects[SPE_BLANK_PAPER].oc_name_known
-                                            || carrying(MAGIC_MARKER))
-                                            break;
-                                    }
-                                    otmp->otyp = rnd_class(bases[SPBOOK_CLASS], SPE_BLANK_PAPER);
-                                }
-                                bless(otmp);
-                                at_your_feet("An object");
-                                dropy(otmp);
-                                godvoice(u.ualign.type, "Use this gift skillfully!");
-                                u.ugifts++;
-                                u.ublesscnt = rnz(300 + (50 * u.ugifts));
-                                exercise(A_WIS, TRUE);
-                                livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
-                                                "had %s given to %s by %s", an(xname(otmp)),
-                                                uhim(), u_gname());
-                                if (!Hallucination && !Blind) {
-                                    otmp->dknown = 1;
-                                    makeknown(otmp->otyp);
-                                }
-                                return 1;
-                            }
-                        } else if (Role_if(PM_MONK)
-                                   && (!Race_if(PM_GIANT) || !Race_if(PM_CENTAUR))) {
-                            typ = rn2(2) ? rnd_class(ELVEN_HELM, HELM_OF_TELEPATHY)
-                                         : rnd_class(GLOVES, LEVITATION_BOOTS);
-                        } else if (Race_if(PM_GIANT)) {
-                            typ = rn2(2) ? rnd_class(ELVEN_HELM, HELM_OF_TELEPATHY)
-                                         : rnd_class(SMALL_SHIELD, LEVITATION_BOOTS);
-                        } else if (Race_if(PM_CENTAUR)) {
-                            typ = rnd_class(ELVEN_HELM, GAUNTLETS_OF_DEXTERITY);
-                        } else {
-                            typ = rnd_class(ELVEN_HELM, LEVITATION_BOOTS);
-                    }
-		    if (typ) {
-                        otmp = mksobj(typ, FALSE, FALSE);
-			if (otmp) {
-                            if (!rn2(12))
-                                otmp = create_oprop(otmp, FALSE);
-			    bless(otmp);
-			    otmp->spe = rn2(3) + 3; /* +3 to +5 */
-			    otmp->oerodeproof = TRUE;
-                            at_your_feet("An object");
-			    dropy(otmp);
-			    godvoice(u.ualign.type, "Use this gift valorously!");
-			    u.ugifts++;
-			    u.ublesscnt = rnz(300 + (50 * u.ugifts));
-			    exercise(A_WIS, TRUE);
-                            livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
-                                            "had %s entrusted to %s by %s", an(xname(otmp)),
-                                            uhim(), u_gname());
-                            if (!Hallucination && !Blind) {
-                                otmp->dknown = 1;
-			        makeknown(otmp->otyp);
-                            }
-			    return 1;
+						otmp = mkobj(SPBOOK_CLASS, TRUE);
+
+						if (!otmp)
+							return 1;
+
+						while (--trycnt > 0) {
+							if (otmp->otyp != SPE_BLANK_PAPER) {
+								for (sp_no = 0; sp_no < MAXSPELL; sp_no++){
+									if (spl_book[sp_no].sp_id == otmp->otyp)
+										break;
+								}
+								if (sp_no == MAXSPELL && !P_RESTRICTED(spell_skilltype(otmp->otyp)))
+									break; /* usable, but not yet known */
+							} else {
+								if (!objects[SPE_BLANK_PAPER].oc_name_known || carrying(MAGIC_MARKER))
+									break;
+							}
+							otmp->otyp = rnd_class(bases[SPBOOK_CLASS], SPE_BLANK_PAPER);
+						}
+			
+						bless(otmp);
+						at_your_feet("An object");
+						dropy(otmp);
+			
+						godvoice(u.ualign.type, "Use this gift skillfully!");
+						u.ugifts++;
+						u.ublesscnt = rnz(300 + (50 * u.ugifts));
+						exercise(A_WIS, TRUE);
+			
+						livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
+										"had %s given to %s by %s", an(xname(otmp)),
+										uhim(), u_gname());
+			
+						if (!Hallucination && !Blind) {
+							otmp->dknown = 1;
+							makeknown(otmp->otyp);
+						}
+						return 1;
+					} else { // Making armor
+						do {
+							// even chance for each slot
+							// giants are evenly distributed among armor they can wear
+							// monks and centaurs end up more likely to receive certain kinds, but them's the breaks
+							switch (Race_if(PM_GIANT) ? rn1(4, 2) : rn2(6)){
+								case 0:
+									// body armor (inc. shirts)
+									typ = rnd_class(PLATE_MAIL, T_SHIRT);
+									if(!Role_if(PM_MONK) || (typ == T_SHIRT || typ == HAWAIIAN_SHIRT)){
+										break; // monks only can have shirts
+									} // monks have (almost) double chance for cloaks
+								case 1:
+									// cloak
+									typ = rnd_class(MUMMY_WRAPPING, CLOAK_OF_DISPLACEMENT);
+									break;
+								case 2:
+									// boots
+									typ = rnd_class(LOW_BOOTS, LEVITATION_BOOTS);
+									if (!Race_if(PM_CENTAUR)){
+										break;
+									} // centaurs have double chances to get a shield
+								case 3:
+									// shield
+									typ = rnd_class(SMALL_SHIELD, SHIELD_OF_REFLECTION);
+									if(!Role_if(PM_MONK)){
+										break;
+									} // monks have double chances to get gloves
+								case 4:
+									// gloves
+									typ = rnd_class(GLOVES, GAUNTLETS_OF_DEXTERITY);
+									break;
+								case 5:
+									// helm
+									typ = rnd_class(ELVEN_HELM, HELM_OF_TELEPATHY);
+									break;
+								default:
+									typ = HAWAIIAN_SHIRT; // ace ventura approved
+									break;	
+							}
+			
+							/*
+							if (objects[typ].oc_material == IRON && Race_if(PM_ELF))
+								typ = 0;
+							else if (objects[typ].oc_material == MITHRIL && Race_if(PM_ORC))
+								typ = 0;
+							*/ 
+							// Same as weapons, but not as badly obviously 
+				
+							// apply starting inventory subs - so we'll get racial gear if possible
+							if (urace.malenum != PM_HUMAN) {
+								for (int i = 0; inv_subs[i].race_pm != NON_PM; ++i){
+									if (inv_subs[i].race_pm == urace.malenum && typ == inv_subs[i].item_otyp) {
+										typ = inv_subs[i].subs_otyp;
+									}
+								}
+							}
+				
+							// if we have the WRONG race, then let's not do that
+							otmp = mksobj(typ, FALSE, FALSE);
+							if (is_elven_armor(otmp) && !Race_if(PM_ELF)){
+								typ = 0;
+							} else if (is_orcish_armor(otmp) && !Race_if(PM_ORC)){
+								typ = 0;
+							} else if (is_dwarvish_armor(otmp) && !Race_if(PM_DWARF)){
+								typ = 0;
+							}
+							otmp = (struct obj *) 0;
+				
+				
+						} while (ncount++ < 1000 && !typ);
+					}
+			
+					if (typ) {
+						ncount = 0;
+						otmp = mksobj(typ, FALSE, FALSE);
+						
+						if (Race_if(PM_ELF)){
+							while (otmp->material == IRON && ncount++ < 500){
+								otmp = mksobj(typ, FALSE, FALSE);
+								// keep trying for non-iron
+							}
+						}
+						
+						if (Race_if(PM_ORC)){
+							while (otmp->material == MITHRIL && ncount++ < 500){
+								otmp = mksobj(typ, FALSE, FALSE);
+								// keep trying for non-mithril
+							}
+						}
+						
+						if (otmp) {
+			
+							if (!rn2(12))
+								otmp = create_oprop(otmp, FALSE);
+			
+							bless(otmp);
+							otmp->spe = rn2(3) + 3; /* +3 to +5 */
+							otmp->oerodeproof = TRUE;
+							at_your_feet("An object");
+							dropy(otmp);
+			
+							godvoice(u.ualign.type, "Use this gift valorously!");
+							u.ugifts++;
+							u.ublesscnt = rnz(300 + (50 * u.ugifts));
+							exercise(A_WIS, TRUE);
+			
+							livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
+								"had %s entrusted to %s by %s", an(xname(otmp)), uhim(), u_gname());
+			
+							if (!Hallucination && !Blind) {
+								otmp->dknown = 1;
+								makeknown(otmp->otyp);
+							}
+							return 1;
+						}
+					}
+					
+					debugpline0("Failed to create item from typ - no typ");
+				}
+
+			} else if (u.uluck >= 0 && !rn2(10 + (2 * nartifacts))) {
+				otmp = mk_artifact((struct obj *) 0, a_align(u.ux, u.uy));
+				if (otmp) {
+					if (otmp->spe < 0)
+						otmp->spe = 0;
+		
+					bless(otmp);
+					otmp->oerodeproof = TRUE;
+					at_your_feet("An object");
+					dropy(otmp);
+		
+					godvoice(u.ualign.type, "Use my gift wisely!");
+					u.ugifts++;
+					u.ublesscnt = rnz(300 + (50 * nartifacts));
+					exercise(A_WIS, TRUE);
+		
+					livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
+									"had %s bestowed upon %s by %s",
+									otmp->oartifact ? artiname(otmp->oartifact)
+													: an(xname(otmp)),
+									uhim(), align_gname(u.ualign.type));
+
+					/* make sure we can use this weapon */
+					unrestrict_weapon_skill(weapon_type(otmp));
+					if (!Hallucination && !Blind) {
+						otmp->dknown = 1;
+						makeknown(otmp->otyp);
+						discover_artifact(otmp->oartifact);
+					}
+					return 1;
+				}
 			}
-	            }
-		}
-            } else if (u.uluck >= 0 && !rn2(10 + (2 * nartifacts))) {
-                otmp = mk_artifact((struct obj *) 0, a_align(u.ux, u.uy));
-		if (otmp) {
-		    if (otmp->spe < 0)
-                        otmp->spe = 0;
-                    bless(otmp);
-                    otmp->oerodeproof = TRUE;
-                    at_your_feet("An object");
-                    dropy(otmp);
-                    godvoice(u.ualign.type, "Use my gift wisely!");
-                    u.ugifts++;
-                    u.ublesscnt = rnz(300 + (50 * nartifacts));
-                    exercise(A_WIS, TRUE);
-                    livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
-                                    "had %s bestowed upon %s by %s",
-                                    otmp->oartifact ? artiname(otmp->oartifact)
-                                                    : an(xname(otmp)),
-                                    uhim(), align_gname(u.ualign.type));
-		    /* make sure we can use this weapon */
-		    unrestrict_weapon_skill(weapon_type(otmp));
-                    if (!Hallucination && !Blind) {
-                        otmp->dknown = 1;
-                        makeknown(otmp->otyp);
-                        discover_artifact(otmp->oartifact);
-                    }
-	            return 1;
-		}
-            }
-            change_luck((value * LUCKMAX) / (MAXVALUE * 2));
-            if ((int) u.uluck < 0)
-                u.uluck = 0;
-            if (u.uluck != saved_luck) {
-                if (Blind)
-                    You("think %s brushed your %s.", something,
-                        body_part(FOOT));
-                else
-                    You(Hallucination
-                    ? "see crabgrass at your %s.  A funny thing in a dungeon."
-                            : "glimpse a four-leaf clover at your %s.",
-                        makeplural(body_part(FOOT)));
-            }
+
+			change_luck((value * LUCKMAX) / (MAXVALUE * 2));
+
+			if ((int) u.uluck < 0)
+				u.uluck = 0;
+
+			if (u.uluck != saved_luck) {
+				if (Blind)
+					You("think %s brushed your %s.", something,
+						body_part(FOOT));
+				else
+					You(Hallucination
+					? "see crabgrass at your %s.  A funny thing in a dungeon."
+							: "glimpse a four-leaf clover at your %s.",
+						makeplural(body_part(FOOT)));
+			}
+
         }
     }
     return 1;

--- a/src/pray.c
+++ b/src/pray.c
@@ -1908,7 +1908,7 @@ dosacrifice()
             }
         } else {
             int nartifacts = nartifact_exist();
-	        int nchance = u.ulevel + 6;
+            int nchance = u.ulevel + 6;
             boolean primary_casters, primary_casters_priest;
 
             /* Primary casting roles */
@@ -1917,291 +1917,291 @@ dosacrifice()
 
             /* you were already in pretty good standing
              *
-			 * The player can gain an artifact;
-			 * The chance goes down as the number of artifacts goes up.
-				 *
-				 * From SporkHack (heavily modified):
-			 * The player can also get handed just a plain old hunk of weaponry
-			 * or piece of armor, but it will be blessed, +3 to +5, fire/rustproof, and
-			 * if it's a weapon, it'll be in one of the player's available skill
-			 * slots. The lower level you are, the more likely it is that you'll
-			 * get a hunk of ordinary junk rather than an artifact.
-				 *
-			 * Note that no artifact is guaranteed; it's still subject to the
-				 * chances of generating one of those in the first place. These are
-			 * just the chances that an artifact will even be considered as a gift.
-			 *
-			 * level  4: 10% chance  level  9: 20% chance  level 12: 30% chance
-			 * level 14: 40% chance  level 17: 50% chance  level 19: 60% chance
-			 * level 21: 70% chance  level 23: 80% chance  level 24: 90% chance
-			 * level 26: 100% chance
-			 */
-			if (rn2(10) >= (int)((nchance * nchance) / 100)) {
-				if (u.uluck >= 0 && !rn2(6 + (2 * u.ugifts))) {
-					int typ, ncount = 0;
-					if (rn2(2)) { // Making a weapon
-						do {
-							/* Don't give unicorn horns or anything the player's restricted in
-							 * Lets also try to dish out suitable gear based on the player's role */
-							if (primary_casters) {
-								typ = rn2(2) ? rnd_class(DAGGER, ATHAME) : rnd_class(MACE, FLAIL);
-							} else if (primary_casters_priest) {
-								typ = rnd_class(MACE, FLAIL);
-							} else if (Role_if(PM_MONK)) {
-								typ = rnd_class(QUARTERSTAFF, STAFF_OF_WAR);
-							} else {
-								typ = rnd_class(SPEAR, KATANA);
-							}
-				
-							// apply starting inventory subs - so we'll get racial gear if possible
-							if (urace.malenum != PM_HUMAN) {
-								for (int i = 0; inv_subs[i].race_pm != NON_PM; ++i){
-									if (inv_subs[i].race_pm == urace.malenum && typ == inv_subs[i].item_otyp) {
-										typ = inv_subs[i].subs_otyp;
-										break;
-									}
-								}
-							}
-				
-							/*
-							if (objects[typ].oc_material == IRON && Race_if(PM_ELF))
-								typ = 0;
-							else if (objects[typ].oc_material == MITHRIL && Race_if(PM_ORC))
-								typ = 0;
-							*/ 
-							// The issue here is it blocks elves from getting basically 
-							// anything, since most (non-elven) weapons are base mat iron...
-								
-							// if we have the WRONG race, then let's not do that
-							otmp = mksobj(typ, FALSE, FALSE);
-							if (is_elven_obj(otmp) && !Race_if(PM_ELF)){
-								typ = 0;
-							} else if (is_orcish_obj(otmp) && !Race_if(PM_ORC)){
-								typ = 0;
-							} else if (is_dwarvish_obj(otmp) && !Race_if(PM_DWARF)){
-								typ = 0;
-							}
-							
-							otmp = (struct obj *) 0;
-							
-							if (typ && !P_RESTRICTED(objects[typ].oc_skill))
-								break;
-						} while (ncount++ < 1000);
+             * The player can gain an artifact;
+             * The chance goes down as the number of artifacts goes up.
+                 *
+                 * From SporkHack (heavily modified):
+             * The player can also get handed just a plain old hunk of weaponry
+             * or piece of armor, but it will be blessed, +3 to +5, fire/rustproof, and
+             * if it's a weapon, it'll be in one of the player's available skill
+             * slots. The lower level you are, the more likely it is that you'll
+             * get a hunk of ordinary junk rather than an artifact.
+                 *
+             * Note that no artifact is guaranteed; it's still subject to the
+                 * chances of generating one of those in the first place. These are
+             * just the chances that an artifact will even be considered as a gift.
+             *
+             * level  4: 10% chance  level  9: 20% chance  level 12: 30% chance
+             * level 14: 40% chance  level 17: 50% chance  level 19: 60% chance
+             * level 21: 70% chance  level 23: 80% chance  level 24: 90% chance
+             * level 26: 100% chance
+             */
+            if (rn2(10) >= (int)((nchance * nchance) / 100)) {
+                if (u.uluck >= 0 && !rn2(6 + (2 * u.ugifts))) {
+                    int typ, ncount = 0;
+                    if (rn2(2)) { // Making a weapon
+                        do {
+                            /* Don't give unicorn horns or anything the player's restricted in
+                             * Lets also try to dish out suitable gear based on the player's role */
+                            if (primary_casters) {
+                                typ = rn2(2) ? rnd_class(DAGGER, ATHAME) : rnd_class(MACE, FLAIL);
+                            } else if (primary_casters_priest) {
+                                typ = rnd_class(MACE, FLAIL);
+                            } else if (Role_if(PM_MONK)) {
+                                typ = rnd_class(QUARTERSTAFF, STAFF_OF_WAR);
+                            } else {
+                                typ = rnd_class(SPEAR, KATANA);
+                            }
+                
+                            // apply starting inventory subs - so we'll get racial gear if possible
+                            if (urace.malenum != PM_HUMAN) {
+                                for (int i = 0; inv_subs[i].race_pm != NON_PM; ++i){
+                                    if (inv_subs[i].race_pm == urace.malenum && typ == inv_subs[i].item_otyp) {
+                                        typ = inv_subs[i].subs_otyp;
+                                        break;
+                                    }
+                                }
+                            }
+                
+                            /*
+                            if (objects[typ].oc_material == IRON && Race_if(PM_ELF))
+                                typ = 0;
+                            else if (objects[typ].oc_material == MITHRIL && Race_if(PM_ORC))
+                                typ = 0;
+                            */ 
+                            // The issue here is it blocks elves from getting basically 
+                            // anything, since most (non-elven) weapons are base mat iron...
+                                
+                            // if we have the WRONG race, then let's not do that
+                            otmp = mksobj(typ, FALSE, FALSE);
+                            if (is_elven_obj(otmp) && !Race_if(PM_ELF)){
+                                typ = 0;
+                            } else if (is_orcish_obj(otmp) && !Race_if(PM_ORC)){
+                                typ = 0;
+                            } else if (is_dwarvish_obj(otmp) && !Race_if(PM_DWARF)){
+                                typ = 0;
+                            }
+                            
+                            otmp = (struct obj *) 0;
+                            
+                            if (typ && !P_RESTRICTED(objects[typ].oc_skill))
+                                break;
+                        } while (ncount++ < 1000);
 
-						if (ncount > 999) {
-							debugpline0("Ran out of tries making weapon");
-							return 1;
-						}
-					} else if ((primary_casters || primary_casters_priest) && !rn2(3)) { // Making a spellbook
-						int sp_no, trycnt = u.ulevel + 1;
+                        if (ncount > 999) {
+                            debugpline0("Ran out of tries making weapon");
+                            return 1;
+                        }
+                    } else if ((primary_casters || primary_casters_priest) && !rn2(3)) { // Making a spellbook
+                        int sp_no, trycnt = u.ulevel + 1;
 
-						otmp = mkobj(SPBOOK_CLASS, TRUE);
+                        otmp = mkobj(SPBOOK_CLASS, TRUE);
 
-						if (!otmp)
-							return 1;
+                        if (!otmp)
+                            return 1;
 
-						while (--trycnt > 0) {
-							if (otmp->otyp != SPE_BLANK_PAPER) {
-								for (sp_no = 0; sp_no < MAXSPELL; sp_no++){
-									if (spl_book[sp_no].sp_id == otmp->otyp)
-										break;
-								}
-								if (sp_no == MAXSPELL && !P_RESTRICTED(spell_skilltype(otmp->otyp)))
-									break; /* usable, but not yet known */
-							} else {
-								if (!objects[SPE_BLANK_PAPER].oc_name_known || carrying(MAGIC_MARKER))
-									break;
-							}
-							otmp->otyp = rnd_class(bases[SPBOOK_CLASS], SPE_BLANK_PAPER);
-						}
-			
-						bless(otmp);
-						at_your_feet("An object");
-						dropy(otmp);
-			
-						godvoice(u.ualign.type, "Use this gift skillfully!");
-						u.ugifts++;
-						u.ublesscnt = rnz(300 + (50 * u.ugifts));
-						exercise(A_WIS, TRUE);
-			
-						livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
-										"had %s given to %s by %s", an(xname(otmp)),
-										uhim(), u_gname());
-			
-						if (!Hallucination && !Blind) {
-							otmp->dknown = 1;
-							makeknown(otmp->otyp);
-						}
-						return 1;
-					} else { // Making armor
-						do {
-							// even chance for each slot
-							// giants are evenly distributed among armor they can wear
-							// monks and centaurs end up more likely to receive certain kinds, but them's the breaks
-							switch (Race_if(PM_GIANT) ? rn1(4, 2) : rn2(6)){
-								case 0:
-									// body armor (inc. shirts)
-									typ = rnd_class(PLATE_MAIL, T_SHIRT);
-									if(!Role_if(PM_MONK) || (typ == T_SHIRT || typ == HAWAIIAN_SHIRT)){
-										break; // monks only can have shirts
-									} // monks have (almost) double chance for cloaks
-								case 1:
-									// cloak
-									typ = rnd_class(MUMMY_WRAPPING, CLOAK_OF_DISPLACEMENT);
-									break;
-								case 2:
-									// boots
-									typ = rnd_class(LOW_BOOTS, LEVITATION_BOOTS);
-									if (!Race_if(PM_CENTAUR)){
-										break;
-									} // centaurs have double chances to get a shield
-								case 3:
-									// shield
-									typ = rnd_class(SMALL_SHIELD, SHIELD_OF_REFLECTION);
-									if(!Role_if(PM_MONK)){
-										break;
-									} // monks have double chances to get gloves
-								case 4:
-									// gloves
-									typ = rnd_class(GLOVES, GAUNTLETS_OF_DEXTERITY);
-									break;
-								case 5:
-									// helm
-									typ = rnd_class(ELVEN_HELM, HELM_OF_TELEPATHY);
-									break;
-								default:
-									typ = HAWAIIAN_SHIRT; // ace ventura approved
-									break;	
-							}
-			
-							/*
-							if (objects[typ].oc_material == IRON && Race_if(PM_ELF))
-								typ = 0;
-							else if (objects[typ].oc_material == MITHRIL && Race_if(PM_ORC))
-								typ = 0;
-							*/ 
-							// Same as weapons, but not as badly obviously 
-				
-							// apply starting inventory subs - so we'll get racial gear if possible
-							if (urace.malenum != PM_HUMAN) {
-								for (int i = 0; inv_subs[i].race_pm != NON_PM; ++i){
-									if (inv_subs[i].race_pm == urace.malenum && typ == inv_subs[i].item_otyp) {
-										typ = inv_subs[i].subs_otyp;
-									}
-								}
-							}
-				
-							// if we have the WRONG race, then let's not do that
-							otmp = mksobj(typ, FALSE, FALSE);
-							if (is_elven_armor(otmp) && !Race_if(PM_ELF)){
-								typ = 0;
-							} else if (is_orcish_armor(otmp) && !Race_if(PM_ORC)){
-								typ = 0;
-							} else if (is_dwarvish_armor(otmp) && !Race_if(PM_DWARF)){
-								typ = 0;
-							}
-							otmp = (struct obj *) 0;
-				
-				
-						} while (ncount++ < 1000 && !typ);
-					}
-			
-					if (typ) {
-						ncount = 0;
-						otmp = mksobj(typ, FALSE, FALSE);
-						
-						if (Race_if(PM_ELF)){
-							while (otmp->material == IRON && ncount++ < 500){
-								otmp = mksobj(typ, FALSE, FALSE);
-								// keep trying for non-iron
-							}
-						}
-						
-						if (Race_if(PM_ORC)){
-							while (otmp->material == MITHRIL && ncount++ < 500){
-								otmp = mksobj(typ, FALSE, FALSE);
-								// keep trying for non-mithril
-							}
-						}
-						
-						if (otmp) {
-			
-							if (!rn2(12))
-								otmp = create_oprop(otmp, FALSE);
-			
-							bless(otmp);
-							otmp->spe = rn2(3) + 3; /* +3 to +5 */
-							otmp->oerodeproof = TRUE;
-							at_your_feet("An object");
-							dropy(otmp);
-			
-							godvoice(u.ualign.type, "Use this gift valorously!");
-							u.ugifts++;
-							u.ublesscnt = rnz(300 + (50 * u.ugifts));
-							exercise(A_WIS, TRUE);
-			
-							livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
-								"had %s entrusted to %s by %s", an(xname(otmp)), uhim(), u_gname());
-			
-							if (!Hallucination && !Blind) {
-								otmp->dknown = 1;
-								makeknown(otmp->otyp);
-							}
-							return 1;
-						}
-					}
-					
-					debugpline0("Failed to create item from typ - no typ");
-				}
+                        while (--trycnt > 0) {
+                            if (otmp->otyp != SPE_BLANK_PAPER) {
+                                for (sp_no = 0; sp_no < MAXSPELL; sp_no++){
+                                    if (spl_book[sp_no].sp_id == otmp->otyp)
+                                        break;
+                                }
+                                if (sp_no == MAXSPELL && !P_RESTRICTED(spell_skilltype(otmp->otyp)))
+                                    break; /* usable, but not yet known */
+                            } else {
+                                if (!objects[SPE_BLANK_PAPER].oc_name_known || carrying(MAGIC_MARKER))
+                                    break;
+                            }
+                            otmp->otyp = rnd_class(bases[SPBOOK_CLASS], SPE_BLANK_PAPER);
+                        }
+            
+                        bless(otmp);
+                        at_your_feet("An object");
+                        dropy(otmp);
+            
+                        godvoice(u.ualign.type, "Use this gift skillfully!");
+                        u.ugifts++;
+                        u.ublesscnt = rnz(300 + (50 * u.ugifts));
+                        exercise(A_WIS, TRUE);
+            
+                        livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
+                                        "had %s given to %s by %s", an(xname(otmp)),
+                                        uhim(), u_gname());
+            
+                        if (!Hallucination && !Blind) {
+                            otmp->dknown = 1;
+                            makeknown(otmp->otyp);
+                        }
+                        return 1;
+                    } else { // Making armor
+                        do {
+                            // even chance for each slot
+                            // giants are evenly distributed among armor they can wear
+                            // monks and centaurs end up more likely to receive certain kinds, but them's the breaks
+                            switch (Race_if(PM_GIANT) ? rn1(4, 2) : rn2(6)){
+                                case 0:
+                                    // body armor (inc. shirts)
+                                    typ = rnd_class(PLATE_MAIL, T_SHIRT);
+                                    if(!Role_if(PM_MONK) || (typ == T_SHIRT || typ == HAWAIIAN_SHIRT)){
+                                        break; // monks only can have shirts
+                                    } // monks have (almost) double chance for cloaks
+                                case 1:
+                                    // cloak
+                                    typ = rnd_class(MUMMY_WRAPPING, CLOAK_OF_DISPLACEMENT);
+                                    break;
+                                case 2:
+                                    // boots
+                                    typ = rnd_class(LOW_BOOTS, LEVITATION_BOOTS);
+                                    if (!Race_if(PM_CENTAUR)){
+                                        break;
+                                    } // centaurs have double chances to get a shield
+                                case 3:
+                                    // shield
+                                    typ = rnd_class(SMALL_SHIELD, SHIELD_OF_REFLECTION);
+                                    if(!Role_if(PM_MONK)){
+                                        break;
+                                    } // monks have double chances to get gloves
+                                case 4:
+                                    // gloves
+                                    typ = rnd_class(GLOVES, GAUNTLETS_OF_DEXTERITY);
+                                    break;
+                                case 5:
+                                    // helm
+                                    typ = rnd_class(ELVEN_HELM, HELM_OF_TELEPATHY);
+                                    break;
+                                default:
+                                    typ = HAWAIIAN_SHIRT; // ace ventura approved
+                                    break;    
+                            }
+            
+                            /*
+                            if (objects[typ].oc_material == IRON && Race_if(PM_ELF))
+                                typ = 0;
+                            else if (objects[typ].oc_material == MITHRIL && Race_if(PM_ORC))
+                                typ = 0;
+                            */ 
+                            // Same as weapons, but not as badly obviously 
+                
+                            // apply starting inventory subs - so we'll get racial gear if possible
+                            if (urace.malenum != PM_HUMAN) {
+                                for (int i = 0; inv_subs[i].race_pm != NON_PM; ++i){
+                                    if (inv_subs[i].race_pm == urace.malenum && typ == inv_subs[i].item_otyp) {
+                                        typ = inv_subs[i].subs_otyp;
+                                    }
+                                }
+                            }
+                
+                            // if we have the WRONG race, then let's not do that
+                            otmp = mksobj(typ, FALSE, FALSE);
+                            if (is_elven_armor(otmp) && !Race_if(PM_ELF)){
+                                typ = 0;
+                            } else if (is_orcish_armor(otmp) && !Race_if(PM_ORC)){
+                                typ = 0;
+                            } else if (is_dwarvish_armor(otmp) && !Race_if(PM_DWARF)){
+                                typ = 0;
+                            }
+                            otmp = (struct obj *) 0;
+                
+                
+                        } while (ncount++ < 1000 && !typ);
+                    }
+            
+                    if (typ) {
+                        ncount = 0;
+                        otmp = mksobj(typ, FALSE, FALSE);
+                        
+                        if (Race_if(PM_ELF)){
+                            while (otmp->material == IRON && ncount++ < 500){
+                                otmp = mksobj(typ, FALSE, FALSE);
+                                // keep trying for non-iron
+                            }
+                        }
+                        
+                        if (Race_if(PM_ORC)){
+                            while (otmp->material == MITHRIL && ncount++ < 500){
+                                otmp = mksobj(typ, FALSE, FALSE);
+                                // keep trying for non-mithril
+                            }
+                        }
+                        
+                        if (otmp) {
+            
+                            if (!rn2(12))
+                                otmp = create_oprop(otmp, FALSE);
+            
+                            bless(otmp);
+                            otmp->spe = rn2(3) + 3; /* +3 to +5 */
+                            otmp->oerodeproof = TRUE;
+                            at_your_feet("An object");
+                            dropy(otmp);
+            
+                            godvoice(u.ualign.type, "Use this gift valorously!");
+                            u.ugifts++;
+                            u.ublesscnt = rnz(300 + (50 * u.ugifts));
+                            exercise(A_WIS, TRUE);
+            
+                            livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
+                                "had %s entrusted to %s by %s", an(xname(otmp)), uhim(), u_gname());
+            
+                            if (!Hallucination && !Blind) {
+                                otmp->dknown = 1;
+                                makeknown(otmp->otyp);
+                            }
+                            return 1;
+                        }
+                    }
+                    
+                    debugpline0("Failed to create item from typ - no typ");
+                }
 
-			} else if (u.uluck >= 0 && !rn2(10 + (2 * nartifacts))) {
-				otmp = mk_artifact((struct obj *) 0, a_align(u.ux, u.uy));
-				if (otmp) {
-					if (otmp->spe < 0)
-						otmp->spe = 0;
-		
-					bless(otmp);
-					otmp->oerodeproof = TRUE;
-					at_your_feet("An object");
-					dropy(otmp);
-		
-					godvoice(u.ualign.type, "Use my gift wisely!");
-					u.ugifts++;
-					u.ublesscnt = rnz(300 + (50 * nartifacts));
-					exercise(A_WIS, TRUE);
-		
-					livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
-									"had %s bestowed upon %s by %s",
-									otmp->oartifact ? artiname(otmp->oartifact)
-													: an(xname(otmp)),
-									uhim(), align_gname(u.ualign.type));
+            } else if (u.uluck >= 0 && !rn2(10 + (2 * nartifacts))) {
+                otmp = mk_artifact((struct obj *) 0, a_align(u.ux, u.uy));
+                if (otmp) {
+                    if (otmp->spe < 0)
+                        otmp->spe = 0;
+        
+                    bless(otmp);
+                    otmp->oerodeproof = TRUE;
+                    at_your_feet("An object");
+                    dropy(otmp);
+        
+                    godvoice(u.ualign.type, "Use my gift wisely!");
+                    u.ugifts++;
+                    u.ublesscnt = rnz(300 + (50 * nartifacts));
+                    exercise(A_WIS, TRUE);
+        
+                    livelog_printf (LL_DIVINEGIFT | LL_ARTIFACT,
+                                    "had %s bestowed upon %s by %s",
+                                    otmp->oartifact ? artiname(otmp->oartifact)
+                                                    : an(xname(otmp)),
+                                    uhim(), align_gname(u.ualign.type));
 
-					/* make sure we can use this weapon */
-					unrestrict_weapon_skill(weapon_type(otmp));
-					if (!Hallucination && !Blind) {
-						otmp->dknown = 1;
-						makeknown(otmp->otyp);
-						discover_artifact(otmp->oartifact);
-					}
-					return 1;
-				}
-			}
+                    /* make sure we can use this weapon */
+                    unrestrict_weapon_skill(weapon_type(otmp));
+                    if (!Hallucination && !Blind) {
+                        otmp->dknown = 1;
+                        makeknown(otmp->otyp);
+                        discover_artifact(otmp->oartifact);
+                    }
+                    return 1;
+                }
+            }
 
-			change_luck((value * LUCKMAX) / (MAXVALUE * 2));
+            change_luck((value * LUCKMAX) / (MAXVALUE * 2));
 
-			if ((int) u.uluck < 0)
-				u.uluck = 0;
+            if ((int) u.uluck < 0)
+                u.uluck = 0;
 
-			if (u.uluck != saved_luck) {
-				if (Blind)
-					You("think %s brushed your %s.", something,
-						body_part(FOOT));
-				else
-					You(Hallucination
-					? "see crabgrass at your %s.  A funny thing in a dungeon."
-							: "glimpse a four-leaf clover at your %s.",
-						makeplural(body_part(FOOT)));
-			}
+            if (u.uluck != saved_luck) {
+                if (Blind)
+                    You("think %s brushed your %s.", something,
+                        body_part(FOOT));
+                else
+                    You(Hallucination
+                    ? "see crabgrass at your %s.  A funny thing in a dungeon."
+                            : "glimpse a four-leaf clover at your %s.",
+                        makeplural(body_part(FOOT)));
+            }
 
         }
     }


### PR DESCRIPTION
Ideally this will fix the following issues:
 - Giants and centaurs shouldn't be able to get armor they can't wear (should have been already fixed, cleaner now though)
 - Elves and orcs shouldn't get items whose material they hate (mainly elves with iron)
 - (minor issue) racial gear should only be given to that race (so a dwarf won't get an elven dagger), and if possible convert standard gear into racial (dagger -> elven dagger if you're an elf, spear -> orcish spear for orcs, etc.)

Does NOT touch the spellbook giving code at all, except maybe some whitespace. Tested as best I could, no crashes and it seems to work as intended.

Rarely, elf PCs with awful weapon skills (mainly rangers, seems like) can get REALLY unlucky rolls on weapons (and not get any). This is because the code just clears racial gear that doesn't match the race (so if they get an orcish one it won't convert to elven, just reroll completely), and if you happen to not land on a weapon you can use then you're out of luck. To compensate, the rolls has been upped to 1000 (and a debug message added if it bypasses that). This should only really be a problem with maybe rangers and rogues, anybody who doesn't get too many weapon skills (of weapons possible to get gifted, spear through katana).