### PR TITLE
Fix crash when a kicked object is disintegrated

### DIFF
--- a/src/dokick.c
+++ b/src/dokick.c
@@ -724,7 +724,8 @@ xchar x, y;
                    : thitmonst(mon, kickedobj)) /* hit && used up? */
             return 1;
     }
-
+    // kickedobj might be disint'd by a black D, or some such that makes this unsafe - RW
+	if (!kickedobj) return 1;
     /* the object might have fallen down a hole;
        ship_object() will have taken care of shop billing */
     if (kickedobj->where == OBJ_MIGRATING)


### PR DESCRIPTION
dokick.c line 730 included `kickedobj->where`, which isn't very safe if `kickedobj` was deleted in `hmon`. This was safe for things like cream pies, where `thitmonst` returned 0 properly, but for objects deleted elsewhere it broke. 