### PR TITLE
Fix deaf & blind hero `seeing' monster

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -1326,15 +1326,7 @@ const char *name;
             if (rn2(3)) {
                 mtmp = makemon(&mons[PM_GREY_ELF], u.ux, u.uy, MM_ADJACENTOK);
                 if (mtmp) {
-                    if (Blind && !Deaf) {
-                        if (Hallucination)
-                            You("hear the sounds of silence.");
-                        else
-                            You("hear movement nearby.");
-                        You("hear somebody say: %s is not yours to take! %s it!",
-                            artiname(obj->oartifact),
-                            rn2(2) ? "Relinquish" : "Return");
-                    } else {
+                    if (!Blind) {
                         if (Hallucination)
                             You("see the second coming of the Prophet.");
                         else
@@ -1345,6 +1337,14 @@ const char *name;
                                   Monnam(mtmp),
                                   artiname(obj->oartifact),
                                   rn2(2) ? "Relinquish" : "Return");
+                    } else if (!Deaf) {
+                        if (Hallucination)
+                            You("hear the sounds of silence.");
+                        else
+                            You("hear movement nearby.");
+                        You("hear somebody say: %s is not yours to take! %s it!",
+                            artiname(obj->oartifact),
+                            rn2(2) ? "Relinquish" : "Return");
                     }
                     /* random chance of some helpers */
                     if (rn2(3))


### PR DESCRIPTION
Naming an artifact may sometimes cause an enemy to appear, much like wishing for an artifact. A bug in the tests determining how this is announced meant that characters who are both deaf & blind would get a message about seeing someone `step out of the shadows':
<img width="604" alt="Screen Shot 2020-08-05 at 9 31 28 PM" src="https://user-images.githubusercontent.com/40038830/89481472-c4b3ae00-d765-11ea-83d3-cdb191163758.png">