### PR TITLE
Shopkeepers make the appropriate noises on save/restore

### DIFF
--- a/src/shk.c
+++ b/src/shk.c
@@ -259,6 +259,7 @@ restshk(shkp, ghostly)
 struct monst *shkp;
 boolean ghostly;
 {
+	shkp->data->msound = MS_SELL;
     if (u.uz.dlevel) {
         struct eshk *eshkp = ESHK(shkp);
 


### PR DESCRIPTION
Previously, restoring overwrote the msound as part of resetting mtmp->data. This fixes that - assuming all shopkeepers should do MS_SELL, and that isshk is true if and only if mtmp is a shopkeeper.