### PR TITLE
Make player monsters show the right rank titles

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -181,6 +181,7 @@ E void NDECL(timebot);
 E int FDECL(xlev_to_rank, (int));
 E const char *NDECL(rank);
 E const char *FDECL(rank_of, (int, SHORT_P, BOOLEAN_P));
+E const char *FDECL(rank_of_mplayer, (int, SHORT_P, BOOLEAN_P));
 E int FDECL(title_to_mon, (const char *, int *, int *));
 E void NDECL(max_rank_sz);
 #ifdef SCORE_ON_BOTL

--- a/include/you.h
+++ b/include/you.h
@@ -176,7 +176,9 @@ struct Role {
 };
 
 extern const struct Role roles[]; /* table of available roles */
+extern const struct Role align_roles[]; /* table of available roles */
 extern struct Role urole;
+
 #define Role_if(X) (urole.malenum == (X))
 #define Role_switch (urole.malenum)
 

--- a/src/botl.c
+++ b/src/botl.c
@@ -16,7 +16,7 @@ const char *const enc_stat[] = { "",         "Burdened",  "Stressed",
 STATIC_OVL NEARDATA int mrank_sz = 0; /* loaded by max_rank_sz (from u_init) */
 STATIC_DCL void NDECL(bot_via_windowport);
 STATIC_DCL void NDECL(stat_update_time);
-STATIC_DCL const char *FDECL(rank_of_role, (int, struct Role *, boolean));
+STATIC_DCL const char *FDECL(rank_of_role, (int, const struct Role *, boolean));
 
 /* limit of the player's name in the status window */
 #define BOTL_NSIZ 16
@@ -293,7 +293,6 @@ short monnum;
 boolean female;
 {
     register const struct Role *role;
-    register int i;
 
     /* Find the role */
     for (role = roles; role->name.m; role++)
@@ -316,7 +315,6 @@ short monnum;
 boolean female;
 {
     register const struct Role *role;
-    register int i;
 
     /* Find the role */
     for (role = roles; role->name.m; role++)
@@ -324,7 +322,15 @@ boolean female;
             break;
     if (!role->name.m)
         role = &urole;
-
+    
+    // convert knights -> dark knights for lawfuls
+     if (role->malenum == PM_KNIGHT){
+          if (u.ualignbase[A_ORIGINAL] == A_LAWFUL)
+               role = &align_roles[0];
+          else if (u.ualignbase[A_ORIGINAL] == A_NEUTRAL && rn2(2))
+               role = &align_roles[0];
+          // otherwise (chaotic, unaligned) keep the standard knight role titles
+     }
     return rank_of_role(lev, role, female);
 }
 

--- a/src/botl.c
+++ b/src/botl.c
@@ -16,6 +16,7 @@ const char *const enc_stat[] = { "",         "Burdened",  "Stressed",
 STATIC_OVL NEARDATA int mrank_sz = 0; /* loaded by max_rank_sz (from u_init) */
 STATIC_DCL void NDECL(bot_via_windowport);
 STATIC_DCL void NDECL(stat_update_time);
+STATIC_DCL const char *FDECL(rank_of_role, (int, struct Role *, boolean));
 
 /* limit of the player's name in the status window */
 #define BOTL_NSIZ 16
@@ -286,7 +287,7 @@ int rank;
 #endif
 
 const char *
-rank_of(lev, monnum, female)
+rank_of(lev, monnum, female) // for the PC only
 int lev;
 short monnum;
 boolean female;
@@ -305,6 +306,37 @@ boolean female;
         role = &urole;
     }
 
+    return rank_of_role(lev, role, female);
+}
+
+const char *
+rank_of_mplayer(lev, monnum, female)
+int lev;
+short monnum;
+boolean female;
+{
+    register const struct Role *role;
+    register int i;
+
+    /* Find the role */
+    for (role = roles; role->name.m; role++)
+        if (monnum == role->malenum || monnum == role->femalenum)
+            break;
+    if (!role->name.m)
+        role = &urole;
+
+    return rank_of_role(lev, role, female);
+}
+
+
+const char *
+rank_of_role(lev, role, female)
+int lev;
+const struct Role *role;
+boolean female;
+{
+    register int i;
+    
     /* Find the rank */
     for (i = xlev_to_rank((int) lev); i >= 0; i--) {
         if (female && role->rank[i].f)
@@ -320,6 +352,8 @@ boolean female;
         return role->name.m;
     return "Player";
 }
+
+
 
 const char *
 rank()

--- a/src/mplayer.c
+++ b/src/mplayer.c
@@ -96,7 +96,7 @@ char *nam;
     else
         mtmp->female = 0;
     Strcat(nam, " the ");
-    Strcat(nam, rank_of((int) mtmp->m_lev, monsndx(mtmp->data) + 18,
+    Strcat(nam, rank_of_mplayer((int) mtmp->m_lev, monsndx(mtmp->data) + 18,
                         (boolean) mtmp->female));
 }
 


### PR DESCRIPTION
Previously, the dark knight exception was overwriting them for chaotic knight players (so they're all named the dark knight titles, regardless of their simulated role).

Shouldn't be savebreaking. I tried to test and it didn't seem to have any errors there, and it shouldn't be changing anything that affects save files, but I'm going to guess old player monsters would still have funky titles? Not a real issue though.