### PR TITLE
Fix check_wings crash on game restore

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -630,7 +630,6 @@ unsigned int *stuckid, *steedid;
     /* current time is the time to use for next urealtime.realtime update */
     urealtime.start_timing = getnow();
 
-    set_uasmon();
 #ifdef CLIPPING
     cliparound(u.ux, u.uy);
 #endif
@@ -690,10 +689,6 @@ unsigned int *stuckid, *steedid;
         if (otmp->owornmask)
             setworn(otmp, otmp->owornmask);
 
-    /* after inventory has been loaded and setworn() is in effect, check
-       crowned infidels (demonic form) for its wings, ensure they stay
-       tucked away under their body armor upon reload */
-    check_wings(TRUE);
     /* reset weapon so that player will get a reminder about "bashing"
        during next fight when bare-handed or wielding an unconventional
        item; for pick-axe, we aren't able to distinguish between having
@@ -885,6 +880,8 @@ register int fd;
         return 0;
     }
     restlevelstate(stuckid, steedid);
+    set_uasmon();
+
 #ifdef INSURANCE
     savestateinlock();
 #endif


### PR DESCRIPTION
`dorecover` calls `restgamestate` then `restlevelstate`. `restlevelstate` does the needed to assign a monster to usteed... meaning for `restgamestate`, `usteed` is gonna be funky. I think that's also partially due to the save & load not storing the actual permonst data, since it's unneeded, and is read back from the original monster in `restlevelstate` anyway.

The issue is that `restgamestate` calls both `check_wings(TRUE)` directly, and also calls `set_uasmon` (which checks wings itself). For both of these, you'll have funky behavior when `check_wings` tries to use the `Flying` macro (which checks `usteed`). Now, the first `check_wings` is removed, leaving only the indirect one, and `set_uasmon` is moved to directly after both the `restgamestate` block and the `restlevelstate` call. This shouldn't break anything, since that function only sets a couple properties & the like, but if intrinsics start vanishing on saving & loading mysterious give that a poke.