### PR TITLE
Fix samurai quest monsters having odd interactions

### DIFF
--- a/include/mondata.h
+++ b/include/mondata.h
@@ -183,9 +183,7 @@
 #define is_hobbit(ptr) \
     ((((ptr)->mhflags & MH_HOBBIT) != 0L) \
      || ((ptr) == youmonst.data && !Upolyd && Race_if(PM_HOBBIT)))
-#define is_giant(ptr) \
-    ((((ptr)->mhflags & MH_GIANT) != 0L) \
-     || ((ptr) == youmonst.data && !Upolyd && Race_if(PM_GIANT)))
+#define is_giant(ptr) (((ptr)->mhflags & MH_GIANT) != 0L)
 #define is_centaur(ptr) \
     ((((ptr)->mhflags & MH_CENTAUR) != 0L) \
      || ((ptr) == youmonst.data && !Upolyd && Race_if(PM_CENTAUR)))
@@ -265,9 +263,7 @@
 #define cantwield(ptr) (nohands(ptr) || verysmall(ptr))
 #define could_twoweap(ptr) ((ptr)->mattk[1].aatyp == AT_WEAP)
 #define cantweararm(ptr) (breakarm(ptr) || sliparm(ptr))
-#define throws_rocks(ptr) \
-    ((((ptr)->mflags2 & M2_ROCKTHROW) != 0L) \
-     || ((ptr) == youmonst.data && !Upolyd && Race_if(PM_GIANT)))
+#define throws_rocks(ptr) (((ptr)->mflags2 & M2_ROCKTHROW) != 0L)
 #define type_is_pname(ptr) (((ptr)->mflags2 & M2_PNAME) != 0L)
 #define is_lord(ptr) (((ptr)->mflags2 & M2_LORD) != 0L)
 #define is_prince(ptr) (((ptr)->mflags2 & M2_PRINCE) != 0L)

--- a/src/apply.c
+++ b/src/apply.c
@@ -1638,7 +1638,7 @@ int x, y;
     /* let giants jump over boulders (what about Flying?
        and is there really enough head room for giants to jump
        at all, let alone over something tall?) */
-    if (sobj_at(BOULDER, x, y) && !throws_rocks(youmonst.data))
+    if (sobj_at(BOULDER, x, y) && !(throws_rocks(youmonst.data) || (Race_if(PM_GIANT) && !Upolyd)))
         return FALSE;
     return TRUE;
 }

--- a/src/do.c
+++ b/src/do.c
@@ -308,7 +308,7 @@ const char *verb;
                 }
                 mtmp->mtrapped = 0;
             } else {
-                if (!Passes_walls && !throws_rocks(youmonst.data)) {
+                if (!Passes_walls && !(throws_rocks(youmonst.data) || (Race_if(PM_GIANT) && !Upolyd))) {
                     losehp(Maybe_Half_Phys(rnd(15)),
                            "squished under a boulder", NO_KILLER_PREFIX);
                     goto deletedwithboulder;

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -1870,7 +1870,7 @@ boolean called;
             Strcat(buf, name);
             name_at_start = TRUE;
         }
-    } else if (is_mplayer(mdat) && !In_endgame(&u.uz)) {
+    } else if ((is_mplayer(mdat) || is_actual_player(mdat)) && !In_endgame(&u.uz)) {
         char pbuf[BUFSZ];
 
         Strcpy(pbuf, rank_of((int) mtmp->m_lev, monsndx(mdat),

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -75,7 +75,7 @@ int shotlimit;
         return 0;
     }
     if ((obj->oartifact == ART_MJOLLNIR && ACURR(A_STR) < STR19(25))
-        || (obj->otyp == BOULDER && !throws_rocks(youmonst.data))) {
+        || (obj->otyp == BOULDER && !(throws_rocks(youmonst.data) || (Race_if(PM_GIANT) && !Upolyd)))) {
         pline("It's too heavy.");
         return 1;
     }

--- a/src/hack.c
+++ b/src/hack.c
@@ -3440,9 +3440,9 @@ inv_weight()
     while (otmp) {
         if (otmp->oclass == COIN_CLASS)
             wt += (int) (((long) otmp->quan + 50L) / 100L);
-        else if (otmp->otyp == BOULDER && throws_rocks(youmonst.data))
+        else if (otmp->otyp == BOULDER && (throws_rocks(youmonst.data) || (Race_if(PM_GIANT) && !Upolyd)))
             wt += GIANT_BLDR_WEIGHT * otmp->quan;
-        else if (otmp->otyp != BOULDER || !throws_rocks(youmonst.data))
+        else if (otmp->otyp != BOULDER || !(throws_rocks(youmonst.data) || (Race_if(PM_GIANT) && !Upolyd)))
             wt += otmp->owt;
         otmp = otmp->nobj;
     }

--- a/src/invent.c
+++ b/src/invent.c
@@ -1493,7 +1493,7 @@ register const char *let, *word;
 
     /* another ugly check: show boulders (not statues) */
     if (*let == WEAPON_CLASS && !strcmp(word, "throw")
-        && throws_rocks(youmonst.data))
+        && ((throws_rocks(youmonst.data) || (Race_if(PM_GIANT) && !Upolyd))))
         useboulder = TRUE;
 
     if (allownone)

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1319,7 +1319,8 @@ register int after;
     if ((!mtmp->mpeaceful || !rn2(10)) && (!Is_rogue_level(&u.uz))) {
         boolean in_line = (lined_up(mtmp)
                && (distmin(mtmp->mx, mtmp->my, mtmp->mux, mtmp->muy)
-                   <= (throws_rocks(youmonst.data) ? 20 : ACURRSTR / 2 + 1)));
+                   <= ((throws_rocks(youmonst.data) || (Race_if(PM_GIANT) && !Upolyd))
+                                                               ? 20 : ACURRSTR / 2 + 1)));
 
         if (appr != 1 || !in_line) {
             /* Monsters in combat won't pick stuff up, avoiding the

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1411,7 +1411,7 @@ boolean telekinesis;
        and for boulder picked up by hero poly'd into a giant; override
        availability of open inventory slot iff not already carrying one */
     if (obj->otyp == LOADSTONE
-        || (obj->otyp == BOULDER && throws_rocks(youmonst.data))) {
+        || (obj->otyp == BOULDER && (throws_rocks(youmonst.data) || (Race_if(PM_GIANT) && !Upolyd)))) {
         if (inv_cnt(FALSE) < 52 || !carrying(obj->otyp)
             || merge_choice(invent, obj))
             return 1; /* lift regardless of current situation */

--- a/src/pray.c
+++ b/src/pray.c
@@ -156,7 +156,9 @@ stuck_in_wall()
             if (!isok(x, y)
                 || (IS_ROCK(levl[x][y].typ)
                     && (levl[x][y].typ != SDOOR && levl[x][y].typ != SCORR))
-                || (blocked_boulder(i, j) && !throws_rocks(youmonst.data)))
+                || (blocked_boulder(i, j) && !(throws_rocks(youmonst.data) ||
+                                                        (Race_if(PM_GIANT) && !Upolyd)))
+				)
                 ++count;
         }
     }

--- a/src/trap.c
+++ b/src/trap.c
@@ -590,7 +590,7 @@ unsigned ftflags;
                  && !(ftflags & TOOKPLUNGE))
              || (Inhell && !u.uevent.invoked && newlevel == bottom)) {
         /* Give player giants a hint... */
-        if (is_giant(youmonst.data))
+        if (maybe_polyd(is_giant(youmonst.data), Race_if(PM_GIANT)))
             dont_fall = "don't fall, but you can climb down.";
         else
             dont_fall = "don't fall in.";


### PR DESCRIPTION
The "samurai" on the samurai quest (not the quest guardians, the monsters you fight) were being misnamed and having funky behavior. They weren't getting their rank titles (due to a change in the definition of `is_mplayer`), and they were getting your racial traits due to an overloading of the PM_SAMURAI part. This should fix that.