### PR TITLE
Dragon swallowing changes

### DIFF
--- a/include/mondata.h
+++ b/include/mondata.h
@@ -123,6 +123,7 @@
 #define mindless(ptr) (((ptr)->mflags1 & M1_MINDLESS) != 0L)
 #define humanoid(ptr) (((ptr)->mflags1 & M1_HUMANOID) != 0L)
 #define is_animal(ptr) (((ptr)->mflags1 & M1_ANIMAL) != 0L)
+#define is_swallower(ptr) (is_animal(ptr) || is_dragon(ptr))
 #define slithy(ptr) (((ptr)->mflags1 & M1_SLITHY) != 0L)
 #define is_wooden(ptr) ((ptr) == &mons[PM_WOOD_GOLEM])
 #define thick_skinned(ptr) (((ptr)->mflags1 & M1_THICK_HIDE) != 0L)

--- a/src/apply.c
+++ b/src/apply.c
@@ -2645,8 +2645,8 @@ struct obj *otmp;
     else if (Stunned)
         what = "while stunned";
     else if (u.uswallow)
-        what =
-            is_animal(u.ustuck->data) ? "while swallowed" : "while engulfed";
+        what = is_swallower(u.ustuck->data) ? "while swallowed"
+                                            : "while engulfed";
     else if (Underwater)
         what = "underwater";
     else if (Levitation)

--- a/src/detect.c
+++ b/src/detect.c
@@ -1831,7 +1831,7 @@ openit()
     int num = 0;
 
     if (u.uswallow) {
-        if (is_animal(u.ustuck->data)) {
+        if (is_swallower(u.ustuck->data)) {
             if (Blind)
                 pline("Its mouth opens!");
             else

--- a/src/dig.c
+++ b/src/dig.c
@@ -1425,12 +1425,11 @@ zap_dig()
         mtmp = u.ustuck;
 
         if (!is_whirly(mtmp->data)) {
-            if (is_animal(mtmp->data) || is_dragon(mtmp->data))
+            if (is_swallower(mtmp->data))
                 You("pierce %s %s wall!", s_suffix(mon_nam(mtmp)),
                     mbodypart(mtmp, STOMACH));
             mtmp->mhp = (mtmp->mhp + 1) / 2; /* not almost dead */
-            expels(mtmp, mtmp->data,
-                   !(is_animal(mtmp->data) || is_dragon(mtmp->data)));
+            expels(mtmp, mtmp->data, !is_swallower(mtmp->data));
         }
         return;
     } /* swallowed */

--- a/src/do.c
+++ b/src/do.c
@@ -992,7 +992,7 @@ boolean with_impact;
             if (is_unpaid(obj))
                 (void) stolen_value(obj, u.ux, u.uy, TRUE, FALSE);
             (void) mpickobj(u.ustuck, obj);
-            if (is_animal(u.ustuck->data)) {
+            if (is_swallower(u.ustuck->data)) {
                 if (could_poly || could_slime) {
                     (void) newcham(u.ustuck,
                                    could_poly ? (struct permonst *) 0
@@ -1290,7 +1290,7 @@ dodown()
 
     if (u.ustuck) {
         You("are %s, and cannot go down.",
-            !u.uswallow ? "being held" : is_animal(u.ustuck->data)
+            !u.uswallow ? "being held" : is_swallower(u.ustuck->data)
                                              ? "swallowed"
                                              : "engulfed");
         return 1;
@@ -1400,7 +1400,7 @@ doup()
     }
     if (u.ustuck) {
         You("are %s, and cannot go up.",
-            !u.uswallow ? "being held" : is_animal(u.ustuck->data)
+            !u.uswallow ? "being held" : is_swallower(u.ustuck->data)
                                              ? "swallowed"
                                              : "engulfed");
         return 1;

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -917,7 +917,7 @@ dokick()
             You_cant("move your %s!", body_part(LEG));
             break;
         case 1:
-            if (is_animal(u.ustuck->data)) {
+            if (is_swallower(u.ustuck->data)) {
                 pline("%s burps loudly.", Monnam(u.ustuck));
                 break;
             }

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1932,7 +1932,7 @@ register struct obj *obj; /* thrownobj or kickedobj or uwep */
         /* this assumes that guaranteed_hit is due to swallowing */
         wakeup(mon, TRUE);
         if (obj->otyp == CORPSE && touch_petrifies(&mons[obj->corpsenm])) {
-            if (is_animal(u.ustuck->data)) {
+            if (is_swallower(u.ustuck->data)) {
                 minstapetrify(u.ustuck, TRUE);
                 /* Don't leave a cockatrice corpse available in a statue */
                 if (!u.uswallow) {
@@ -1943,7 +1943,7 @@ register struct obj *obj; /* thrownobj or kickedobj or uwep */
         }
         pline("%s into %s %s.", Tobjnam(obj, "vanish"),
               s_suffix(mon_nam(mon)),
-              is_animal(u.ustuck->data) ? "entrails" : "currents");
+              is_swallower(u.ustuck->data) ? "entrails" : "currents");
     } else {
         tmiss(obj, mon, TRUE);
     }
@@ -2354,7 +2354,7 @@ struct obj *obj;
     }
     freeinv(obj);
     if (u.uswallow) {
-        pline(is_animal(u.ustuck->data) ? "%s in the %s's entrails."
+        pline(is_swallower(u.ustuck->data) ? "%s in the %s's entrails."
                                         : "%s into %s.",
               "The money disappears", mon_nam(u.ustuck));
         add_to_minv(u.ustuck, obj);

--- a/src/end.c
+++ b/src/end.c
@@ -577,9 +577,13 @@ int how;
     if (ukiller && (likes_gold(ukiller->data) || likes_gems(ukiller->data)
                     || likes_objs(ukiller->data) || likes_magic(ukiller->data)
                     || is_covetous(ukiller->data))) {
-        if (!Lifesaved)
-            pline("%s starts to %s your possessions...", Monnam(ukiller),
-                  rn2(2) ? "ransack" : "rummage through");
+        if (!Lifesaved) {
+            if (!u.uswallow)
+                pline("%s starts to %s your possessions...", Monnam(ukiller),
+                        rn2(2) ? "ransack" : "rummage through");
+            else if (ukiller == u.ustuck && is_swallower(u.ustuck->data))
+                pline("%s emits a satisfied belch.", Monnam(ukiller));
+        }
     }
 
     /*

--- a/src/end.c
+++ b/src/end.c
@@ -485,6 +485,10 @@ int how;
     return FALSE;
 }
 
+#define is_rummager(ptr) \
+    (likes_gold(ptr) || likes_gems(ptr) || likes_objs(ptr) \
+     || likes_magic(ptr) || is_covetous(ptr))
+
 void
 done_in_by(mtmp, how)
 struct monst *mtmp;
@@ -574,16 +578,14 @@ int how;
 
     Strcpy(killer.name, buf);
     ukiller = mtmp;
-    if (ukiller && (likes_gold(ukiller->data) || likes_gems(ukiller->data)
-                    || likes_objs(ukiller->data) || likes_magic(ukiller->data)
-                    || is_covetous(ukiller->data))) {
-        if (!Lifesaved) {
-            if (!u.uswallow)
-                pline("%s starts to %s your possessions...", Monnam(ukiller),
-                        rn2(2) ? "ransack" : "rummage through");
-            else if (ukiller == u.ustuck && is_swallower(u.ustuck->data))
-                pline("%s emits a satisfied belch.", Monnam(ukiller));
-        }
+    if (!Lifesaved && ukiller) {
+        if (!u.uswallow && is_rummager(ukiller->data))
+            pline("%s starts to %s your possessions...", Monnam(ukiller),
+                  (nohands(ukiller->data) || nolimbs(ukiller->data))
+                    ? "root through" : rn2(2) ? "ransack"
+                                              : "rummage through");
+        else if (ukiller == u.ustuck && is_swallower(u.ustuck->data))
+            pline("%s emits a satisfied belch.", Monnam(ukiller));
     }
 
     /*

--- a/src/engrave.c
+++ b/src/engrave.c
@@ -183,7 +183,7 @@ register int x, y;
 {
     register struct rm *lev = &levl[x][y];
 
-    if (x == u.ux && y == u.uy && u.uswallow && is_animal(u.ustuck->data))
+    if (x == u.ux && y == u.uy && u.uswallow && is_swallower(u.ustuck->data))
         return "maw";
     else if (IS_AIR(lev->typ) && (Is_airlevel(&u.uz) || In_V_tower(&u.uz)))
         return "air";
@@ -569,7 +569,7 @@ doengrave()
     /* Can the adventurer engrave at all? */
 
     if (u.uswallow) {
-        if (is_animal(u.ustuck->data)) {
+        if (is_swallower(u.ustuck->data)) {
             pline("What would you write?  \"Jonah was here\"?");
             return 0;
         } else if (is_whirly(u.ustuck->data)) {

--- a/src/explode.c
+++ b/src/explode.c
@@ -349,7 +349,7 @@ int expltype;
                 if (u.uswallow && mtmp == u.ustuck) {
                     const char *adj = (char *) 0;
 
-                    if (is_animal(u.ustuck->data)) {
+                    if (is_swallower(u.ustuck->data)) {
                         switch (adtyp) {
                         case AD_FIRE:
                             adj = "heartburn";

--- a/src/hack.c
+++ b/src/hack.c
@@ -2926,7 +2926,7 @@ pickup_checks()
     /* uswallow case added by GAN 01/29/87 */
     if (u.uswallow) {
         if (!u.ustuck->minvent) {
-            if (is_animal(u.ustuck->data)) {
+            if (is_swallower(u.ustuck->data)) {
                 You("pick up %s tongue.", s_suffix(mon_nam(u.ustuck)));
                 pline("But it's kind of slimy, so you drop it.");
             } else

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -399,7 +399,7 @@ struct permonst *mdat; /* if mtmp is polymorphed, mdat != mtmp->data */
 boolean message;
 {
     if (message) {
-        if (is_animal(mdat)) {
+        if (is_swallower(mdat)) {
             You("get regurgitated!");
         } else {
             char blast[40];
@@ -966,7 +966,7 @@ register struct monst *mtmp;
                     } else {
                         missmu(mtmp, tmp, j, mattk);
                     }
-                } else if (is_animal(mtmp->data)) {
+                } else if (is_swallower(mtmp->data)) {
                     pline("%s gulps some air!", Monnam(mtmp));
                 } else {
                     if (youseeit)
@@ -2387,7 +2387,7 @@ struct attack *mattk;
         place_monster(mtmp, u.ux, u.uy);
         u.ustuck = mtmp;
         newsym(mtmp->mx, mtmp->my);
-        if (is_animal(mtmp->data) && u.usteed) {
+        if (is_swallower(mtmp->data) && u.usteed) {
             char buf[BUFSZ];
 
             /* Too many quirks presently if hero and steed
@@ -2648,7 +2648,7 @@ struct attack *mattk;
         ; /* life-saving has already expelled swallowed hero */
     } else if (touch_petrifies(youmonst.data) && !resists_ston(mtmp)) {
         pline("%s very hurriedly %s you!", Monnam(mtmp),
-              is_animal(mtmp->data) ? "regurgitates" : "expels");
+              is_swallower(mtmp->data) ? "regurgitates" : "expels");
         expels(mtmp, mtmp->data, FALSE);
     } else if (!u.uswldtim || youmonst.data->msize >= MZ_HUGE) {
         /* As of 3.6.2: u.uswldtim used to be set to 0 by life-saving but it
@@ -2657,7 +2657,7 @@ struct attack *mattk;
            swallowed is still possible */
         expels(mtmp, mtmp->data, TRUE);
         if (flags.verbose
-            && (is_animal(mtmp->data)
+            && (is_swallower(mtmp->data)
                 || (dmgtype(mtmp->data, AD_DGST) && Slow_digestion)))
             pline("Obviously %s doesn't like your taste.", mon_nam(mtmp));
     }

--- a/src/mon.c
+++ b/src/mon.c
@@ -3148,7 +3148,7 @@ struct monst *mdef;
         wasinside = TRUE;
     mondead(mdef);
     if (wasinside) {
-        if (is_animal(mdef->data))
+        if (is_swallower(mdef->data))
             You("%s through an opening in the new %s.",
                 locomotion(youmonst.data, "jump"), xname(otmp));
     }
@@ -4829,7 +4829,7 @@ boolean msg;      /* "The oldmon turns into a newmon!" */
                     if (is_vampshifter(mtmp)) {
                         Sprintf(msgtrail, " which was a shapeshifted %s",
                                 noname_monnam(mtmp, ARTICLE_NONE));
-                    } else if (is_animal(mdat)) {
+                    } else if (is_swallower(mdat)) {
                         Strcpy(msgtrail, "'s stomach");
                     } else {
                         msgtrail[0] = '\0';

--- a/src/pager.c
+++ b/src/pager.c
@@ -307,7 +307,7 @@ int x, y;
     }
     if (u.ustuck == mtmp) {
         if (u.uswallow || iflags.save_uswallow) /* monster detection */
-            Strcat(buf, is_animal(mtmp->data)
+            Strcat(buf, is_swallower(mtmp->data)
                           ? ", swallowing you" : ", engulfing you");
         else
             Strcat(buf, (Upolyd && sticks(youmonst.data))

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -943,7 +943,7 @@ boolean FDECL((*allow), (OBJ_P)); /* allow function */
         any = zeroany;
         if (sorted && n > 1) {
             Sprintf(buf, "%s Creatures",
-                    is_animal(u.ustuck->data) ? "Swallowed" : "Engulfed");
+                    is_swallower(u.ustuck->data) ? "Swallowed" : "Engulfed");
             add_menu(win, NO_GLYPH, &any, 0, 0, iflags.menu_headings, buf,
                      MENU_UNSELECTED);
         }

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1256,7 +1256,7 @@ dospinweb()
     }
     if (u.uswallow) {
         You("release web fluid inside %s.", mon_nam(u.ustuck));
-        if (is_animal(u.ustuck->data)) {
+        if (is_swallower(u.ustuck->data)) {
             expels(u.ustuck, u.ustuck->data, TRUE);
             return 0;
         }
@@ -1527,8 +1527,8 @@ dohide()
     if (u.ustuck || (u.utrap && (u.utraptype != TT_PIT || on_ceiling))) {
         You_cant("hide while you're %s.",
                  !u.ustuck ? "trapped"
-                   : u.uswallow ? (is_animal(u.ustuck->data) ? "swallowed"
-                                                             : "engulfed")
+                   : u.uswallow ? (is_swallower(u.ustuck->data) ? "swallowed"
+                                                                : "engulfed")
                      : !sticks(youmonst.data) ? "being held"
                        : (humanoid(u.ustuck->data) ? "holding someone"
                                                    : "holding that creature"));

--- a/src/priest.c
+++ b/src/priest.c
@@ -1090,7 +1090,8 @@ struct monst *mtmp;
                       : !u.uswallow ? ", holding you"
                          : attacktype_fordmg(u.ustuck->data, AT_ENGL, AD_DGST)
                             ? ", digesting you"
-                            : is_animal(u.ustuck->data) ? ", swallowing you"
+                            : is_swallower(u.ustuck->data)
+                               ? ", swallowing you"
                                : ", engulfing you");
     if (mtmp == u.usteed)
         Strcat(info, ", carrying you");

--- a/src/read.c
+++ b/src/read.c
@@ -2052,7 +2052,7 @@ struct obj *obj;
         if (u.uswallow) {
             if (Blind)
                 ; /* no feedback */
-            else if (is_animal(u.ustuck->data))
+            else if (is_swallower(u.ustuck->data))
                 pline("%s %s is lit.", s_suffix(Monnam(u.ustuck)),
                       mbodypart(u.ustuck, STOMACH));
             else if (is_whirly(u.ustuck->data))

--- a/src/spell.c
+++ b/src/spell.c
@@ -831,7 +831,7 @@ cast_protection()
                                    ? "mist"
                                    : is_whirly(u.ustuck->data)
                                       ? "maelstrom"
-                                      : is_animal(u.ustuck->data)
+                                      : is_swallower(u.ustuck->data)
                                          ? "maw"
                                          : "ooze")
                                 : (u.uinwater

--- a/src/trap.c
+++ b/src/trap.c
@@ -3231,10 +3231,10 @@ float_up()
     } else if (u.uinwater) {
         spoteffects(TRUE);
     } else if (u.uswallow) {
-        You(is_animal(u.ustuck->data) ? "float away from the %s."
-                                      : "spiral up into %s.",
-            is_animal(u.ustuck->data) ? surface(u.ux, u.uy)
-                                      : mon_nam(u.ustuck));
+        You(is_swallower(u.ustuck->data) ? "float away from the %s."
+                                         : "spiral up into %s.",
+            is_swallower(u.ustuck->data) ? surface(u.ux, u.uy)
+                                         : mon_nam(u.ustuck));
     } else if (Hallucination) {
         pline("Up, up, and awaaaay!  You're walking on air!");
     } else if (Is_airlevel(&u.uz)) {
@@ -3320,7 +3320,7 @@ long hmask, emask; /* might cancel timeout */
     }
     if (u.uswallow) {
         You("float down, but you are still %s.",
-            is_animal(u.ustuck->data) ? "swallowed" : "engulfed");
+            is_swallower(u.ustuck->data) ? "swallowed" : "engulfed");
         (void) encumber_msg();
         return 1;
     }

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -2860,9 +2860,10 @@ register struct attack *mattk;
                 if (DEADMONSTER(mdef)) /* not lifesaved */
                     return 2;
             }
-            You("%s %s!", is_animal(youmonst.data) ? "regurgitate" : "expel",
+            You("%s %s!", is_swallower(youmonst.data) ? "regurgitate"
+                                                      : "expel",
                 mon_nam(mdef));
-            if (Slow_digestion || is_animal(youmonst.data)) {
+            if (Slow_digestion || is_swallower(youmonst.data)) {
                 pline("Obviously, you didn't like %s taste.",
                       s_suffix(mon_nam(mdef)));
             }

--- a/src/zap.c
+++ b/src/zap.c
@@ -377,7 +377,7 @@ struct obj *otmp;
     case SPE_KNOCK:
         wake = FALSE; /* don't want immediate counterattack */
         if (u.uswallow && mtmp == u.ustuck) {
-            if (is_animal(mtmp->data)) {
+            if (is_swallower(mtmp->data)) {
                 if (Blind)
                     You_feel("a sudden rush of air!");
                 else


### PR DESCRIPTION
Treat dragons as animal-like creatures for the sake of messages and effects related to their engulfing attacks (they have a stomach, etc).  `is_animal` was previously used to distinguish between animal-like "swallowing" creatures and other "engulfing" creatures (Juiblex, fog clouds), but this placed dragons into the wrong category.

Also prevents engulfing monsters who have killed you from "ransacking" their own stomach contents, and adds an alternative post-death message for animal-like engulfers ("You die... The black dragon emits a satisfied belch.").

Edit: Also adds "root through" as an alternative term to "rummage through" and "ransack" for creatures without hands/limbs.