### PR TITLE
Fix logic problem with belch message

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -579,13 +579,14 @@ int how;
     Strcpy(killer.name, buf);
     ukiller = mtmp;
     if (!Lifesaved && ukiller) {
-        if (!u.uswallow && is_rummager(ukiller->data))
+        if (u.uswallow) {
+            if (ukiller == u.ustuck && is_swallower(u.ustuck->data))
+                pline("%s emits a satisfied belch.", Monnam(ukiller));
+        } else if is_rummager(ukiller->data)
             pline("%s starts to %s your possessions...", Monnam(ukiller),
                   (nohands(ukiller->data) || nolimbs(ukiller->data))
                     ? "root through" : rn2(2) ? "ransack"
                                               : "rummage through");
-        else if (ukiller == u.ustuck && is_swallower(u.ustuck->data))
-            pline("%s emits a satisfied belch.", Monnam(ukiller));
     }
 
     /*


### PR DESCRIPTION
Something I realized belatedly after #34 was merged and I was going to sleep, so I got out of bed to fix it real quick...

If you were not swallowed, but were stuck to an `M1_ANIMAL` monster with a sticking attack, the belch message could be printed erroneously (for example, this would happen if you were stuck to a giant mimic and it killed you) -- make sure it will only print in the event you are in the creature's stomach when you die.

Good night!