### PR TITLE
Don't leak identity of soko prize tool

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -307,6 +307,7 @@ struct obj {
     (/* (Is_container(o) || (o)->otyp == STATUE) && */ \
      (o)->cobj != (struct obj *) 0)
 #define Is_container(o) ((o)->otyp >= LARGE_BOX && (o)->otyp <= BAG_OF_TRICKS)
+#define Is_nonprize_container(o) (Is_container(o) && !is_soko_prize_flag(o))
 #define Is_box(otmp) (otmp->otyp == LARGE_BOX || otmp->otyp == CHEST \
                       || otmp->otyp == IRON_SAFE || otmp->otyp == CRYSTAL_CHEST)
 #define Is_mbag(otmp) \

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -5807,7 +5807,7 @@ boolean doit;
         Sprintf(buf, "Pick up %s", otmp->nexthere ? "items" : doname(otmp));
         add_herecmd_menuitem(win, dopickup, buf);
 
-        if (Is_container(otmp)) {
+        if (Is_nonprize_container(otmp)) {
             Sprintf(buf, "Loot %s", doname(otmp));
             add_herecmd_menuitem(win, doloot, buf);
         }
@@ -5905,8 +5905,9 @@ int x, y, mod;
                 cmd[0] = cmd_from_func(dodown);
                 return cmd;
             } else if (OBJ_AT(u.ux, u.uy)) {
-                cmd[0] = cmd_from_func(Is_container(level.objects[u.ux][u.uy])
-                                       ? doloot : dopickup);
+                cmd[0] = cmd_from_func(
+                            Is_nonprize_container(level.objects[u.ux][u.uy])
+                                ? doloot : dopickup);
                 return cmd;
             } else {
                 cmd[0] = cmd_from_func(donull); /* just rest */

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -419,7 +419,7 @@ xchar x, y; /* coordinates where object was before the impact, not after */
     boolean costly, insider, frominv;
 
     /* only consider normal containers */
-    if (!Is_container(obj) || !Has_contents(obj) || Is_mbag(obj))
+    if (!Is_nonprize_container(obj) || !Has_contents(obj) || Is_mbag(obj))
         return;
 
     costly = ((shkp = shop_keeper(*in_rooms(x, y, SHOPBASE)))

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -1055,7 +1055,7 @@ register struct obj *container;
                       || m_carrying(mtmp, CREDIT_CARD)))
                   || mtmp->iswiz || is_rider(mtmp->data));
 
-    if (!Is_container(container))
+    if (!Is_nonprize_container(container))
         return FALSE;
 
     if (container->olocked && !can_unlock)

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1677,7 +1677,7 @@ boolean countem;
 
     for (cobj = level.objects[x][y]; cobj; cobj = nobj) {
         nobj = cobj->nexthere;
-        if (Is_container(cobj)) {
+        if (Is_nonprize_container(cobj)) {
             container_count++;
             if (!countem)
                 break;
@@ -1866,7 +1866,7 @@ doloot()
 
             for (cobj = level.objects[cc.x][cc.y]; cobj;
                  cobj = cobj->nexthere)
-                if (Is_container(cobj)) {
+                if (Is_nonprize_container(cobj)) {
                     any.a_obj = cobj;
                     add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE,
                              doname(cobj), MENU_UNSELECTED);
@@ -1893,7 +1893,7 @@ doloot()
             for (cobj = level.objects[cc.x][cc.y]; cobj; cobj = nobj) {
                 nobj = cobj->nexthere;
 
-                if (Is_container(cobj)) {
+                if (Is_nonprize_container(cobj)) {
                     c = ynq(safe_qbuf(qbuf, "There is ", " here, loot it?",
                                       cobj, doname, ansimpleoname,
                                       "a container"));
@@ -3040,7 +3040,7 @@ dotip()
 
                 for (cobj = level.objects[cc.x][cc.y], i = 0; cobj;
                      cobj = cobj->nexthere)
-                    if (Is_container(cobj)) {
+                    if (Is_nonprize_container(cobj)) {
                         ++i;
                         any.a_obj = cobj;
                         add_menu(win, NO_GLYPH, &any, 0, 0, ATR_NONE,
@@ -3082,7 +3082,7 @@ dotip()
             } else {
                 for (cobj = level.objects[cc.x][cc.y]; cobj; cobj = nobj) {
                     nobj = cobj->nexthere;
-                    if (!Is_container(cobj))
+                    if (!Is_nonprize_container(cobj))
                         continue;
                     c = ynq(safe_qbuf(qbuf, "There is ", " here, tip it?",
                                       cobj,
@@ -3105,7 +3105,7 @@ dotip()
         return 0;
 
     /* normal case */
-    if (Is_container(cobj) || cobj->otyp == HORN_OF_PLENTY) {
+    if (Is_nonprize_container(cobj) || cobj->otyp == HORN_OF_PLENTY) {
         tipcontainer(cobj);
         return 1;
     }
@@ -3166,7 +3166,7 @@ boolean creation;
     register struct obj *obj, *nobj, *bag = (struct obj *) 0;
     struct obj *wep = bag, *hwep = bag, *rwep = bag, *proj = bag;
     for (obj = mon->minvent; obj; obj = obj->nobj) {
-        if (!Is_container(obj)
+        if (!Is_nonprize_container(obj)
             || obj->otyp == BAG_OF_TRICKS)
             continue;
         if (obj->otyp == BAG_OF_HOLDING) {


### PR DESCRIPTION
Polyself into a xorn allows the player to phase through the three doors in the Sokoban treasure zoo and examine each prize up-close.  Using the `#loot` command while standing on the 'prize tool' would identify it as a magic marker ("You don't find anything here to loot") or a bag of holding ("It's locked"). Similar results for `#tip`, etc, as well as some stuff with graphical windowports that have contextual commands.

I explicitly did not prevent zapping the tool with a wand of probing, which provides comparable information ("It's empty", etc, if the tool is a bag of holding); imo the other things are exploits of bugs, but the wand of probing thing seems to me like a legitimate & creative strategy that is so niche I felt bad about removing it.

Removing the wand of probing as well would just involve this:
```diff
diff --git a/src/zap.c b/src/zap.c
index 5e9df1ce0..076008495 100644
--- a/src/zap.c
+++ b/src/zap.c
@@ -2056,7 +2056,7 @@ struct obj *obj, *otmp;
             res = !obj->dknown;
             /* target object has now been "seen (up close)" */
             obj->dknown = 1;
-            if (Is_container(obj) || obj->otyp == STATUE) {
+            if (Is_nonprize_container(obj) || obj->otyp == STATUE) {
                 if (obj->otyp != CRYSTAL_CHEST)
                     obj->cknown = obj->lknown = 1;
                 if (obj->otyp == CRYSTAL_CHEST) {
```