### PR TITLE
Add 'readable' Hawaiian shirt designs

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2174,6 +2174,9 @@ E long NDECL(random);
 
 E void FDECL(learnscroll, (struct obj *));
 E char *FDECL(tshirt_text, (struct obj *, char *));
+E char *FDECL(hawaiian_motif, (struct obj *, char *));
+E char *FDECL(apron_text, (struct obj *, char *buf));
+E char *FDECL(striped_text, (struct obj *, char *buf));
 E int NDECL(doread);
 E boolean FDECL(is_chargeable, (struct obj *));
 E void FDECL(recharge, (struct obj *, int, struct monst *));

--- a/include/obj.h
+++ b/include/obj.h
@@ -374,11 +374,11 @@ struct obj {
 /* things that can be read */
 #define is_readable(otmp)                                                    \
     ((otmp)->otyp == FORTUNE_COOKIE || (otmp)->otyp == T_SHIRT               \
-     || (otmp)->otyp == ALCHEMY_SMOCK || (otmp)->otyp == CREDIT_CARD         \
-     || (otmp)->otyp == CAN_OF_GREASE || (otmp)->otyp == MAGIC_MARKER        \
-     || (otmp)->oclass == COIN_CLASS || (otmp)->oartifact == ART_GJALLAR     \
-     || (otmp)->otyp == CANDY_BAR || (otmp)->oartifact == ART_MAGIC___BALL   \
-     || (otmp)->otyp == STRIPED_SHIRT)
+     || (otmp)->otyp == ALCHEMY_SMOCK || (otmp)->otyp == HAWAIIAN_SHIRT      \
+     || (otmp)->otyp == CREDIT_CARD || (otmp)->otyp == CAN_OF_GREASE         \
+     || (otmp)->otyp == MAGIC_MARKER || (otmp)->oclass == COIN_CLASS         \
+     || (otmp)->oartifact == ART_GJALLAR || (otmp)->otyp == STRIPED_SHIRT    \
+     || (otmp)->oartifact == ART_MAGIC___BALL || (otmp)->otyp == CANDY_BAR)
 
 /* special stones */
 #define is_graystone(obj)                                 \

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -917,10 +917,28 @@ unsigned cxn_flags; /* bitmask of CXN_xxx values */
     if (pluralize)
         Strcpy(buf, makeplural(buf));
 
-    if (obj->otyp == T_SHIRT && program_state.gameover) {
+    if (program_state.gameover) {
         char tmpbuf[BUFSZ];
 
-        Sprintf(eos(buf), " with text \"%s\"", tshirt_text(obj, tmpbuf));
+        /* disclose without breaking illiterate conduct, but mainly tip off
+           players who aren't aware that something readable is present */
+        switch (obj->otyp) {
+        case T_SHIRT:
+        case ALCHEMY_SMOCK:
+        case STRIPED_SHIRT:
+            Sprintf(eos(buf), " with text \"%s\"",
+                    (obj->otyp == T_SHIRT)
+                        ? tshirt_text(obj, tmpbuf)
+                        : (obj->otyp == STRIPED_SHIRT)
+                            ? striped_text(obj, tmpbuf)
+                            : apron_text(obj, tmpbuf));
+            break;
+        case HAWAIIAN_SHIRT:
+            Sprintf(eos(buf), " with %s motif", an(hawaiian_motif(obj, tmpbuf)));
+            break;
+        default:
+            break;
+        }
     }
 
     if (has_oname(obj) && dknown) {

--- a/src/read.c
+++ b/src/read.c
@@ -266,6 +266,7 @@ striped_text(striped, buf)
 struct obj *striped;
 char *buf;
 {
+    unsigned msgidx;
     static const char *const striped_msgs[] = {
         "AZ# 85",    /* Al Capone */
         "AZ# 117",   /* George 'Machine Gun' Kelly */
@@ -279,7 +280,10 @@ char *buf;
         "1027820",   /* O.J. Simpson */
     };
 
-    Strcpy(buf, striped_msgs[rn2(SIZE(striped_msgs))]);
+
+    msgidx = striped->o_id ^ (unsigned) ubirthday;
+
+    Strcpy(buf, striped_msgs[msgidx % SIZE(striped_msgs)]);
     return erode_obj_text(striped, buf);
 }
 


### PR DESCRIPTION
Functionally similar to reading a t-shirt or apron, but rather than actual text printed on the shirt being displayed the design of the Hawaiian shirt is instead described.

Note that this means 'reading' a Hawaiian shirt would/should not break illiterate conduct, since there is no actual reading of text involved.

Also added aprons and striped shirts to the list of shirts which have their text included during game-end disclosure (like T-shirts already did), and fixed a bug with the convict shirts that meant the message was re-randomized every time it was read.