### PR TITLE
Don't print "magical" during game-end disclosure

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -601,7 +601,8 @@ unsigned cxn_flags; /* bitmask of CXN_xxx values */
         goto nameit;
 
     if (dknown && (obj->oprops_known & ITEM_MAGICAL)
-        && (((obj->oprops && !(obj->oprops_known & ~ITEM_MAGICAL))
+        && (((obj->oprops && !(obj->oprops_known & ~ITEM_MAGICAL
+                               || dump_prop_flag))
                 && (!objects[obj->otyp].oc_magic
                     || !objects[obj->otyp].oc_name_known))
             || (!obj->oprops && objects[obj->otyp].oc_magic


### PR DESCRIPTION
Unidentified items marked as "magical" for wizards because of their object properties were being listed like this in the DYWYPI list:

    an uncursed +0 magical leather armor of telepathy

Because "magical" should only show up when the specific reason the item is magical has not yet been identified, make sure it isn't included when `dump_item_prop` is enabled (i.e. all item properties will be listed) and object properties are the reason it's marked magical.