### PR TITLE
Unlocking safes and crystal chests

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -315,7 +315,7 @@ struct obj* tobj;
             pline("You attempt to crack the safe using the combination... %s?",
                   rndcolor());
         } else {
-            pick_lock(tobj, rx, ry, safe);
+            pick_lock(tobj, 0, 0, NULL);
             return TRUE;
         }
     }

--- a/src/lock.c
+++ b/src/lock.c
@@ -534,9 +534,11 @@ struct obj *container; /* container, for autounlock */
                     }
                 } 
 
-                if (otmp->otyp == CRYSTAL_CHEST) {
-                    You_cant("%s %ssuch a container via physical means.",
-                             verb, it ? "" : "the lock on");
+                /* crystal chest can only be opened by magical means */
+                if (otmp->otyp == CRYSTAL_CHEST && !pick->oartifact) {
+                    You_cant("%s %ssuch a container with a mundane %s.",
+                             verb, it ? "" : "the lock on ",
+                             simple_typename(picktyp));
                     return PICKLOCK_LEARNED_SOMETHING;
                 }
 

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1742,7 +1742,6 @@ int cindex, ccount; /* index of this container (1..N), number of them (N) */
     if (!cobj)
         return 0;
     if (cobj->olocked) {
-        struct obj *unlocktool;
         if (ccount < 2)
             pline("%s locked.",
                   cobj->lknown ? "It is" : "Hmmm, it turns out to be");
@@ -1751,17 +1750,25 @@ int cindex, ccount; /* index of this container (1..N), number of them (N) */
         else
             pline("Hmmm, %s turns out to be locked.", the(xname(cobj)));
         cobj->lknown = 1;
-        if (flags.autounlock && (unlocktool = carrying(STETHOSCOPE)) != 0) {
-            if (cobj->otyp == IRON_SAFE) {
-                /* pass ox and oy to avoid direction prompt */
-                pick_lock(unlocktool, cobj->ox, cobj->oy, cobj);
+
+        if (flags.autounlock) {
+            struct obj *unlocktool = (struct obj *) 0;
+
+            switch (cobj->otyp) {
+            case IRON_SAFE:
+                unlocktool = carrying(STETHOSCOPE);
+                break;
+            case LARGE_BOX:
+            case CHEST:
+                unlocktool = autokey(TRUE);
+                break;
+            default:
+                break;
             }
-        }
-        if (flags.autounlock && (unlocktool = autokey(TRUE)) != 0) {
-            if (cobj->otyp == LARGE_BOX || cobj->otyp == CHEST) {
+ 
+            if (unlocktool)
                 /* pass ox and oy to avoid direction prompt */
                 return (pick_lock(unlocktool, cobj->ox, cobj->oy, cobj) != 0);
-            }
         }
         return 0;
     }

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1763,6 +1763,9 @@ int cindex, ccount; /* index of this container (1..N), number of them (N) */
                 unlocktool = autokey(TRUE);
                 break;
             default:
+                /* Don't prompt for crystal chest; only artifact unlocking
+                 * tools can unlock it, and we don't want to give that away
+                 * by suggesting them automatically to the user. */
                 break;
             }
  


### PR DESCRIPTION
Mostly this updates the way the player is prompted when unlocking an iron safe: `use_stethoscope` and `pick_lock` now correctly differentiate between using a stethoscope in an `autounlock` context versus directly applying it to the safe, and the verb "crack" (instead of "unlock" or "pick") is always used for safes now.  The patch also includes some more specific feedback when trying to use an inappropriate tool to unlock an iron safe ("you don't see a keyhole that would fit a lock pick" or a similar message, instead of "you aren't sure how to go about opening the safe that way").

After doing that, I thought it might be cool to allow crystal chests to be unlocked with magical (i.e. artifact) unlocking tools, so I added that.  I also updated the message presented upon failure to (un)lock a crystal chest to emphasize that the problem was caused by the tool being 'mundane' rather than 'physical'.  If you want to keep crystal chests impossible to lock with any tools at all, let me know and I can ditch the second commit.