### PR TITLE
Use quotes for spoken text from artifact defenders

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -1332,20 +1332,19 @@ const char *name;
                         else
                             You("see %s step out of the shadows.",
                                 a_monnam(mtmp));
-                        if (!Deaf)
-                            pline("%s says: %s is not yours to take! %s it!",
-                                  Monnam(mtmp),
-                                  artiname(obj->oartifact),
-                                  rn2(2) ? "Relinquish" : "Return");
                     } else if (!Deaf) {
                         if (Hallucination)
                             You("hear the sounds of silence.");
                         else
                             You("hear movement nearby.");
-                        You("hear somebody say: %s is not yours to take! %s it!",
-                            artiname(obj->oartifact),
-                            rn2(2) ? "Relinquish" : "Return");
                     }
+                    if (!Deaf) {
+                        pline("%s says:", Blind ? "Someone" : Monnam(mtmp));
+                        verbalize("%s is not yours to take! %s it!",
+                                    artiname(obj->oartifact),
+                                    rn2(2) ? "Relinquish" : "Return");
+                    }
+
                     /* random chance of some helpers */
                     if (rn2(3))
                         (void) makemon(&mons[PM_GREEN_ELF], u.ux, u.uy, MM_ADJACENTOK | MM_ANGRY);

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -4546,7 +4546,6 @@ struct obj *no_wish;
         int pm = -1;
         int strategy = NEED_HTH_WEAPON;
         struct monst *mtmp;
-        const char *voice = NULL;
         struct obj *otmp2 = (struct obj *) 0;
         /* You can use otmp2 to give the owner some other item you want to.
            Used here to give ammunition for the Ranger artifacts. */
@@ -4699,23 +4698,22 @@ struct obj *no_wish;
             if (Blind) {
                 if (Hallucination)
                     pline("Smells like teen spirit...");
-                else if (!Deaf)
-                    You("hear a small explosion and smell smoke.");
-                if (!Deaf)
-                    You("hear somebody say: Did you think that I would %s %s %s?",
-                        rn2(2) ? "relinquish"
-                               : rn2(2) ? "hand over" : "give you",
-                        aname, rn2(2) ? "so easily" : "without a fight");
+                else
+                    You("%ssmell smoke.",
+                        Deaf ? "" : "hear a small explosion and ");
             } else {
                 if (Hallucination)
-                    pline("Nice colors, but the sound could have been more mellow.");
+                    pline("Nice colors, but %s.",
+                          Deaf ? "funky smell"
+                               : "the sound could have been more mellow");
                 else
                     pline("There is a puff of smoke and a figure appears!");
-                if (!Deaf)
-                    pline("%s says: Did you think that I would %s %s %s?",
-                          voice ? voice : Monnam(mtmp),
+            }
+            if (!Deaf) {
+                pline("%s says:", Blind ? "Someone" : Monnam(mtmp));
+                verbalize("Did you think that I would %s %s %s?",
                           rn2(2) ? "relinquish"
-                                 : rn2(2) ? "hand over" : "give you",
+                                 : (rn2(2) ? "hand over" : "give you"),
                           aname, rn2(2) ? "so easily" : "without a fight");
             }
             (void) mpickobj(mtmp, otmp);


### PR DESCRIPTION
Artifact defenders' speech is formatted like this:
> Andy the Investigator says: Did you really think I would hand over Grayswandir so easily?

But similar constructions elsewhere in the game typically use `verbalize` to surround the spoken text with quotation marks:
> The priestess of Anhur intones: "Pilgrim, you enter a sacred place!"

This commit just brings artifact defenders' speech in line with this format.

Also includes some minor consolidation of duplicate code, as well as tests for deafness in cases where something the hero hears is described when the artifact defender appears.