### PR TITLE
Add & use new wielding_artifact function

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -107,6 +107,7 @@ E void FDECL(retouch_equipment, (int));
 E void NDECL(mkot_trap_warn);
 E boolean FDECL(is_magic_key, (struct monst *, struct obj *));
 E struct obj *FDECL(has_magic_key, (struct monst *));
+E boolean FDECL(wielding_artifact, (int));
 
 /* ### attrib.c ### */
 

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -539,38 +539,27 @@ boolean resuming;
                     for (mtmp = fmon; mtmp; mtmp = mtmp->nmon) {
                         if ((uarmg && uarmg->oartifact == ART_DRAGONBANE
                              && is_dragon(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_STING
-                                         || (u.twoweap && uswapwep->oartifact == ART_STING))
+                            || (wielding_artifact(ART_STING)
                                 && is_orc(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_ORCRIST
-                                         || (u.twoweap && uswapwep->oartifact == ART_ORCRIST))
+                            || (wielding_artifact(ART_ORCRIST)
                                 && is_orc(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_GRIMTOOTH
-                                         || (u.twoweap && uswapwep->oartifact == ART_GRIMTOOTH))
+                            || (wielding_artifact(ART_GRIMTOOTH)
                                 && is_elf(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_GIANTSLAYER
-                                         || (u.twoweap && uswapwep->oartifact == ART_GIANTSLAYER))
+                            || (wielding_artifact(ART_GIANTSLAYER)
                                 && is_giant(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_TROLLSBANE
-                                         || (u.twoweap && uswapwep->oartifact == ART_TROLLSBANE))
+                            || (wielding_artifact(ART_TROLLSBANE)
                                 && is_troll(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_OGRESMASHER
-                                         || (u.twoweap && uswapwep->oartifact == ART_OGRESMASHER))
+                            || (wielding_artifact(ART_OGRESMASHER)
                                 && is_ogre(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_SUNSWORD
-                                         || (u.twoweap && uswapwep->oartifact == ART_SUNSWORD))
+                            || (wielding_artifact(ART_SUNSWORD)
                                 && is_undead(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_WEREBANE
-                                         || (u.twoweap && uswapwep->oartifact == ART_WEREBANE))
+                            || (wielding_artifact(ART_WEREBANE)
                                 && is_were(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_DEMONBANE
-                                         || (u.twoweap && uswapwep->oartifact == ART_DEMONBANE))
+                            || (wielding_artifact(ART_DEMONBANE)
                                 && is_demon(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_ANGELSLAYER
-                                         || (u.twoweap && uswapwep->oartifact == ART_ANGELSLAYER))
+                            || (wielding_artifact(ART_ANGELSLAYER)
                                 && is_angel(mtmp->data))
-                            || (uwep && (uwep->oartifact == ART_VORPAL_BLADE
-                                         || (u.twoweap && uswapwep->oartifact == ART_VORPAL_BLADE))
+                            || (wielding_artifact(ART_VORPAL_BLADE)
                                 && is_jabberwock(mtmp->data))) {
                             if (mtmp->mpeaceful || mtmp->mtame)
                                 mtmp->mpeaceful = mtmp->mtame = 0;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3380,4 +3380,15 @@ struct monst *mon; /* if null, hero assumed */
     return (struct obj *) 0;
 }
 
+boolean
+wielding_artifact(art)
+int art;
+{
+    if (!art)
+        return FALSE;
+
+    return ((uwep && uwep->oartifact == art)
+            || (u.twoweap && uswapwep->oartifact == art));
+}
+
 /*artifact.c*/

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -1151,9 +1151,8 @@ int x;
     register int tmp = (u.abon.a[x] + u.atemp.a[x] + u.acurr.a[x]);
 
     if (x == A_STR) {
-        if (tmp >= 125 || ((uarmg && uarmg->otyp == GAUNTLETS_OF_POWER)
-            || (uwep && uwep->oartifact == ART_GIANTSLAYER)
-            || (u.twoweap && uswapwep->oartifact == ART_GIANTSLAYER)))
+      if (tmp >= 125 || (uarmg && uarmg->otyp == GAUNTLETS_OF_POWER)
+          || wielding_artifact(ART_GIANTSLAYER))
             return (schar) 125;
         else
 #ifdef WIN32_BUG
@@ -1176,8 +1175,7 @@ int x;
                 return (schar) 25;
         }
     } else if (x == A_CON) {
-        if ((uwep && uwep->oartifact == ART_OGRESMASHER)
-            || (u.twoweap && uswapwep->oartifact == ART_OGRESMASHER))
+        if (wielding_artifact(ART_OGRESMASHER))
             return (schar) 25;
     } else if (x == A_INT || x == A_WIS) {
         /* yes, this may raise int/wis if player is sufficiently
@@ -1222,10 +1220,11 @@ int attrindx;
     if (attrindx == A_STR) {
         hilimit = STR19(25); /* 125 */
         /* lower limit for Str can also be 25 */
-        if ((uarmg && uarmg->otyp == GAUNTLETS_OF_POWER) || (uwep && uwep->oartifact == ART_GIANTSLAYER))
+        if ((uarmg && uarmg->otyp == GAUNTLETS_OF_POWER)
+            || wielding_artifact(ART_GIANTSLAYER))
             lolimit = hilimit;
     } else if (attrindx == A_CON) {
-        if (uwep && uwep->oartifact == ART_OGRESMASHER)
+        if (wielding_artifact(ART_OGRESMASHER))
             lolimit = hilimit;
     }
     /* this exception is hypothetical; the only other worn item affecting

--- a/src/detect.c
+++ b/src/detect.c
@@ -1957,8 +1957,11 @@ register int aflag; /* intrinsic autosearch vs explicit searching */
         if (!aflag)
             pline("What are you looking for?  The exit?");
     } else {
-        int fund = (uwep && uwep->oartifact
-                    && spec_ability(uwep, SPFX_SEARCH)) ? uwep->spe : 0;
+        int fund = ((uwep && uwep->oartifact
+                     && spec_ability(uwep, SPFX_SEARCH))
+                    || (u.twoweap && uswapwep->oartifact
+                        && spec_ability(uswapwep, SPFX_SEARCH))) ? uwep->spe
+                                                                 : 0;
 
         if (ublindf && ublindf->otyp == LENSES && !Blind)
             fund += 2; /* JDS: lenses help searching */

--- a/src/hack.c
+++ b/src/hack.c
@@ -1385,8 +1385,7 @@ struct trap *desttrap; /* nonnull if another trap at <x,y> */
         climb_pit();
         break;
     case TT_WEB:
-        if ((uwep && uwep->oartifact == ART_STING)
-            || (u.twoweap && uswapwep->oartifact == ART_STING)) {
+        if (wielding_artifact(ART_STING)) {
             /* escape trap but don't move and don't destroy it */
             u.utrap = 0; /* caller will call reset_utrap() */
             pline("Sting cuts through the web!");

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -2412,7 +2412,7 @@ int mmflags;
     if (is_dprince(ptr) && ptr->msound == MS_BRIBE) {
         mtmp->mpeaceful = mtmp->minvis = mtmp->perminvis = 1;
         mtmp->mavenge = 0;
-        if (uwep && uwep->oartifact == ART_EXCALIBUR)
+        if (wielding_artifact(ART_EXCALIBUR))
             mtmp->mpeaceful = mtmp->mtame = FALSE;
     }
 #ifndef DCC30_BUG

--- a/src/mon.c
+++ b/src/mon.c
@@ -2961,8 +2961,7 @@ boolean was_swallowed; /* digestion */
 
     /* Trolls don't leave a corpse when the player is wielding Trollsbane */
     if (mdat->mlet == S_TROLL
-        && ((uwep && uwep->oartifact == ART_TROLLSBANE)
-            || (u.twoweap && uswapwep->oartifact == ART_TROLLSBANE))) {
+        && wielding_artifact(ART_TROLLSBANE)) {
         if (cansee(mon->mx, mon->my))
             pline("In the presence of Trollsbane, %s corpse flares brightly and burns to ashes.",
                   s_suffix(mon_nam(mon)));
@@ -2971,8 +2970,7 @@ boolean was_swallowed; /* digestion */
 
     /* Zombies don't leave a corpse when the player is wielding Sunsword */
     if (is_zombie(mdat)
-        && ((uwep && uwep->oartifact == ART_SUNSWORD)
-            || (u.twoweap && uswapwep->oartifact == ART_SUNSWORD))) {
+        && wielding_artifact(ART_SUNSWORD)) {
         if (cansee(mon->mx, mon->my))
             pline("In the presence of Sunsword, %s corpse dissolves into nothingness.",
                   s_suffix(mon_nam(mon)));

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -465,7 +465,7 @@ boolean
 can_track(ptr)
 register struct permonst *ptr;
 {
-    if (uwep && uwep->oartifact == ART_EXCALIBUR)
+    if (wielding_artifact(ART_EXCALIBUR))
         return TRUE;
     else
         return (boolean) haseyes(ptr);

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -591,8 +591,7 @@ register struct monst *mtmp;
                       Monnam(mtmp), mhis(mtmp));
             mtmp->mdiseased = 0;
             mtmp->mhp = -1;
-            if ((uwep && uwep->oartifact == ART_GRIMTOOTH)
-                || (u.twoweap && uswapwep->oartifact == ART_GRIMTOOTH))
+            if (wielding_artifact(ART_GRIMTOOTH))
                 xkilled(mtmp, XKILL_GIVEMSG);
             else
                 mondied(mtmp);

--- a/src/pray.c
+++ b/src/pray.c
@@ -831,11 +831,11 @@ gcrownu()
         u.uevent.uhand_of_elbereth = 2;
         /* priests aren't supposed to use edged weapons */
         if (Role_if(PM_PRIEST)) {
-            in_hand = (uwep && uwep->oartifact == ART_MJOLLNIR);
+            in_hand = wielding_artifact(ART_MJOLLNIR);
             already_exists =
                 exist_artifact(HEAVY_WAR_HAMMER, artiname(ART_MJOLLNIR));
         } else {
-            in_hand = (uwep && uwep->oartifact == ART_VORPAL_BLADE);
+            in_hand = wielding_artifact(ART_VORPAL_BLADE);
             already_exists =
                 exist_artifact(LONG_SWORD, artiname(ART_VORPAL_BLADE));
         }
@@ -847,11 +847,11 @@ gcrownu()
         u.uevent.uhand_of_elbereth = 3;
         /* priests aren't supposed to use edged weapons */
         if (Role_if(PM_PRIEST)) {
-            in_hand = (uwep && uwep->oartifact == ART_MJOLLNIR);
+            in_hand = wielding_artifact(ART_MJOLLNIR);
             already_exists =
                 exist_artifact(HEAVY_WAR_HAMMER, artiname(ART_MJOLLNIR));
         } else {
-            in_hand = (uwep && uwep->oartifact == ART_STORMBRINGER);
+            in_hand = wielding_artifact(ART_STORMBRINGER);
             already_exists =
                 exist_artifact(RUNESWORD, artiname(ART_STORMBRINGER));
         }
@@ -1574,7 +1574,7 @@ dosacrifice()
                 value += 1;
             if (is_unicorn(ptr))
                 value += 3;
-            if (uwep && uwep->oartifact == ART_SECESPITA)
+            if (wielding_artifact(ART_SECESPITA))
                 value += value / 2;
             if (otmp->oeaten)
                 value = eaten_stat(value, otmp);

--- a/src/trap.c
+++ b/src/trap.c
@@ -1620,7 +1620,7 @@ unsigned trflags;
             if (Half_physical_damage || Half_spell_damage)
                 dmgval2 += rnd(4);
             /* give Magicbane wielder dose of own medicine */
-            if (uwep && uwep->oartifact == ART_MAGICBANE)
+            if (wielding_artifact(ART_MAGICBANE))
                 dmgval2 += rnd(4);
             /* having an artifact--other than own quest one--which
                confers magic resistance simply by being carried

--- a/src/worn.c
+++ b/src/worn.c
@@ -1226,16 +1226,17 @@ struct obj *obj;
         case RIN_FIRE_RESISTANCE:
             if (!resists_fire(mon))
                 rc = (dmgtype(youmonst.data, AD_FIRE)
-                      || (uwep && uwep->oartifact == ART_FIRE_BRAND)
-                      || (uwep && uwep->oartifact == ART_XIUHCOATL)
-                      || (uwep && uwep->oartifact == ART_ANGELSLAYER)
-                      || (uwep && uwep->oartifact == ART_FIRE_BRAND)
+                      || wielding_artifact(ART_FIRE_BRAND)
+                      || wielding_artifact(ART_XIUHCOATL)
+                      || wielding_artifact(ART_ANGELSLAYER)
+                      || (u.twoweap && uswapwep->oprops & ITEM_FIRE)
                       || (uwep && uwep->oprops & ITEM_FIRE)) ? 20 : 12;
             break;
         case RIN_COLD_RESISTANCE:
             if (!resists_cold(mon))
                 rc = (dmgtype(youmonst.data, AD_COLD)
-                      || (uwep && uwep->oartifact == ART_FROST_BRAND)
+                      || wielding_artifact(ART_FROST_BRAND)
+                      || (u.twoweap && uswapwep->oprops & ITEM_FROST)
                       || (uwep && uwep->oprops & ITEM_FROST)) ? 20 : 12;
             break;
 	case RIN_POISON_RESISTANCE:
@@ -1243,12 +1244,14 @@ struct obj *obj;
                 rc = (dmgtype(youmonst.data, AD_DRST)
                       || dmgtype(youmonst.data, AD_DRCO)
                       || dmgtype(youmonst.data, AD_DRDX)
+                      || (u.twoweap && uswapwep->oprops & ITEM_VENOM)
                       || (uwep && uwep->oprops & ITEM_VENOM)) ? 20 : 10;
             break;
 	case RIN_SHOCK_RESISTANCE:
             if (!resists_elec(mon))
                 rc = (dmgtype(youmonst.data, AD_ELEC)
-                      || (uwep && uwep->oartifact == ART_MJOLLNIR)
+                      || wielding_artifact(ART_MJOLLNIR)
+                      || (u.twoweap && uswapwep->oprops & ITEM_SHOCK)
                       || (uwep && uwep->oprops & ITEM_SHOCK)) ? 20 : 10;
             break;
 	case RIN_REGENERATION:

--- a/src/zap.c
+++ b/src/zap.c
@@ -864,7 +864,7 @@ boolean by_hero;
     if ((mons[montype].mlet == S_EEL
         && !(IS_POOL(levl[x][y].typ) || IS_PUDDLE(levl[x][y].typ)))
         || (mons[montype].mlet == S_TROLL
-            && uwep && uwep->oartifact == ART_TROLLSBANE)) {
+            && wielding_artifact(ART_TROLLSBANE))) {
         if (by_hero && cansee(x, y))
             pline("%s twitches feebly.",
                 upstart(corpse_xname(corpse, (const char *) 0, CXN_PFX_THE)));


### PR DESCRIPTION
Artifact effects were applied inconsistently, in some cases only activating when the artifact is wielded in the main hand (`uwep`) and in others also activating when the artifact is wielded in the off-hand (`uswapwep`).  For example, Excalibur would only prevent bribing a demon prince if wielded in the main hand; if in the off hand while twoweaponing, it would still be possible to bribe the demon.

This commit adds a new function, `wielding_artifact`, that checks both the main and off hand weapons for a particular artifact, and uses it for most cases where artifact effects are activated.

Also adds checks for off-hand weapons to a couple minor tests that only considered `uwep`.