### PR TITLE
Add and use rndrace function for picking races

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1549,6 +1549,7 @@ E void FDECL(decide_to_shapeshift, (struct monst *, int));
 E boolean FDECL(vamp_stone, (struct monst *));
 E boolean FDECL(damage_mon, (struct monst*, int, int));
 E void FDECL(check_gear_next_turn, (struct monst *));
+E int FDECL(rndrace, (int));
 E void FDECL(apply_race, (struct monst *, int));
 
 /* ### mondata.c ### */

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -486,4 +486,6 @@
     ((ptr) == &mons[PM_KATHRYN_THE_ICE_QUEEN] || (ptr) == &mons[PM_KOA] \
      || (ptr) == &mons[PM_OZZY])
 
+#define is_racialmon(ptr) (is_mplayer(ptr) || is_mercenary(ptr))
+
 #endif /* MONDATA_H */

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -2300,6 +2300,7 @@ int mmflags;
        appropriate flags that go along with their race */
     if (is_mplayer(ptr)) {
         char nam[PL_NSIZ];
+        int race;
         struct erac *rptr;
         get_mplname(mtmp, nam);
         mtmp = christen_monst(mtmp, nam);
@@ -2320,51 +2321,22 @@ int mmflags;
         rptr->mattk[1].damn = 1;
         rptr->mattk[1].damd = 6;
 
+        race = rndrace(mndx);
+        apply_race(mtmp, race);
+
         switch (mndx) {
         case PM_ARCHEOLOGIST:
             /* flags for all archeologists regardless of race */
             rptr->mflags1 |= (M1_TUNNEL | M1_NEEDPICK);
-            /* specific flags per race */
-            switch (rnd(4)) {
-            case 1:
-                /* M1 flags already set as archeologist */
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_GNOME);
+            if (race == PM_GNOME)
                 rptr->ralign = 0;
-                break;
-            case 3:
-                apply_race(mtmp, PM_HOBBIT);
-                break;
-            case 4:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_BARBARIAN:
             /* flags for all barbarians regardless of race */
             rptr->mflags3 |= M3_BERSERK;
             mtmp->mintrinsics |= MR_POISON;
-            /* specific flags per race */
-            switch (rnd(5)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
+            if (race == PM_DWARF)
                 rptr->ralign = 0;
-                break;
-            case 2:
-                apply_race(mtmp, PM_ORC);
-                break;
-            case 3:
-                apply_race(mtmp, PM_GIANT);
-                break;
-            case 4:
-                apply_race(mtmp, PM_CENTAUR);
-                break;
-            case 5:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_CAVEMAN:
         case PM_CAVEWOMAN:
@@ -2375,44 +2347,12 @@ int mmflags;
             rptr->mattk[0].adtyp = AD_SAMU;
             rptr->mattk[1].aatyp = rptr->mattk[1].adtyp = 0;
             rptr->mattk[1].damn = rptr->mattk[1].damd = 0;
-            /* specific flags per race */
-            switch (rnd(4)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_GNOME);
+            if (race == PM_GNOME)
                 rptr->ralign = 0;
-                break;
-            case 3:
-                apply_race(mtmp, PM_GIANT);
-                break;
-            case 4:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_CONVICT:
             /* flags for all convicts regardless of race */
             mtmp->mintrinsics |= MR_POISON;
-            /* specific flags per race */
-            switch (rnd(5)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_ORC);
-                break;
-            case 3:
-                apply_race(mtmp, PM_GNOME);
-                break;
-            case 4:
-                apply_race(mtmp, PM_HOBBIT);
-                break;
-            case 5:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_HEALER:
             /* flags for all healers regardless of race */
@@ -2420,24 +2360,6 @@ int mmflags;
             rptr->mattk[1].aatyp = AT_MAGC;
             rptr->mattk[1].adtyp = AD_CLRC;
             mtmp->mintrinsics |= MR_POISON;
-            /* specific flags per race */
-            switch (rnd(5)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_ELF);
-                break;
-            case 3:
-                apply_race(mtmp, PM_GNOME);
-                break;
-            case 4:
-                apply_race(mtmp, PM_HOBBIT);
-                break;
-            case 5:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_INFIDEL:
             /* flags for all infidels regardless of race */
@@ -2445,34 +2367,10 @@ int mmflags;
             rptr->mattk[1].aatyp = AT_MAGC;
             rptr->mattk[1].adtyp = AD_SPEL;
             mtmp->mintrinsics |= MR_FIRE;
-            /* specific flags per race */
-            switch (rnd(3)) {
-            case 1:
-                apply_race(mtmp, PM_ORC);
-                break;
-            case 2:
-                apply_race(mtmp, PM_ILLITHID);
-                rptr->mattk[2].aatyp = AT_TENT;
-                rptr->mattk[2].adtyp = AD_DRIN;
-                rptr->mattk[2].damn = 2;
-                rptr->mattk[2].damd = 1;
-                break;
-            case 3:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_KNIGHT:
-            /* specific flags per race */
-            switch (rnd(2)) {
-            case 1:
-                apply_race(mtmp, PM_ELF);
+            if (race == PM_ELF)
                 rptr->ralign = -3;
-                break;
-            case 2:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_MONK:
             /* flags for all monks regardless of race */
@@ -2483,24 +2381,6 @@ int mmflags;
             rptr->mattk[0].damn = rptr->mattk[1].damn = 1;
             rptr->mattk[0].damd = rptr->mattk[1].damd = 8;
             mtmp->mintrinsics |= (MR_POISON | MR_SLEEP);
-            /* specific flags per race */
-            switch (rnd(5)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_ELF);
-                break;
-            case 3:
-                apply_race(mtmp, PM_GIANT);
-                break;
-            case 4:
-                apply_race(mtmp, PM_CENTAUR);
-                break;
-            case 5:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_PRIEST:
         case PM_PRIESTESS:
@@ -2508,116 +2388,31 @@ int mmflags;
             rptr->mattk[0].adtyp = AD_SAMU;
             rptr->mattk[1].aatyp = AT_MAGC;
             rptr->mattk[1].adtyp = AD_CLRC;
-            /* specific flags per race */
-            switch (rnd(8)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_ELF);
-                break;
-            case 3:
-                apply_race(mtmp, PM_GIANT);
-                break;
-            case 4:
-                apply_race(mtmp, PM_HOBBIT);
-                break;
-            case 5:
-                apply_race(mtmp, PM_CENTAUR);
-                break;
-            case 6:
-                apply_race(mtmp, PM_ORC);
+            if (race == PM_ORC || race == PM_ILLITHID)
                 rptr->ralign = -3;
-                break;
-            case 7:
-                apply_race(mtmp, PM_ILLITHID);
-                rptr->ralign = -3;
-                rptr->mattk[2].aatyp = AT_TENT;
-                rptr->mattk[2].adtyp = AD_DRIN;
-                rptr->mattk[2].damn = 2;
-                rptr->mattk[2].damd = 1;
-                break;
-            case 8:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_RANGER:
             /* flags for all rangers regardless of race */
             rptr->mflags3 |= M3_ACCURATE;
-            /* specific flags per race */
-            switch (rnd(6)) {
-            case 1:
-                apply_race(mtmp, PM_ELF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_GNOME);
-                break;
-            case 3:
-                apply_race(mtmp, PM_HOBBIT);
+            if (race == PM_HOBBIT)
                 rptr->ralign = 0;
-                break;
-            case 4:
-                apply_race(mtmp, PM_CENTAUR);
-                break;
-            case 5:
-                apply_race(mtmp, PM_ORC);
-                break;
-            case 6:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_ROGUE:
             /* flags for all rogues regardless of race */
             rptr->mattk[0].adtyp = AD_SAMU;
             rptr->mattk[1].adtyp = AD_SITM;
             rptr->mflags3 |= M3_ACCURATE;
-            /* specific flags per race */
-            switch (rnd(4)) {
-            case 1:
-                apply_race(mtmp, PM_ELF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_HOBBIT);
+            if (race == PM_HOBBIT)
                 rptr->ralign = 0;
-                break;
-            case 3:
-                apply_race(mtmp, PM_ORC);
-                break;
-            case 4:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_SAMURAI:
             /* flags for all samurai regardless of race */
             /* samurai do 1d8 instead of 1d6 */
             rptr->mattk[0].damn = rptr->mattk[1].damn = 1;
             rptr->mattk[0].damd = rptr->mattk[1].damd = 8;
-            /* specific flags per race */
-            switch (rnd(3)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_GIANT);
-                break;
-            case 3:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_TOURIST:
-            /* specific flags per race */
-            switch (rnd(2)) {
-            case 1:
-                apply_race(mtmp, PM_HOBBIT);
-                break;
-            case 2:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
+            /* nothing special based on role */
             break;
         case PM_VALKYRIE:
             /* flags for all valkyrie regardless of race */
@@ -2625,123 +2420,24 @@ int mmflags;
             rptr->mattk[0].damn = rptr->mattk[1].damn = 1;
             rptr->mattk[0].damd = rptr->mattk[1].damd = 8;
             mtmp->mintrinsics |= MR_COLD;
-            /* specific flags per race */
-            switch (rnd(4)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
+            if (race == PM_DWARF)
                 rptr->ralign = 3;
-                break;
-            case 2:
-                apply_race(mtmp, PM_GIANT);
-                break;
-            case 3:
-                apply_race(mtmp, PM_CENTAUR);
-                break;
-            case 4:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         case PM_WIZARD:
             /* flags for all wizards regardless of race */
             rptr->mattk[0].adtyp = AD_SAMU;
             rptr->mattk[1].aatyp = AT_MAGC;
             rptr->mattk[1].adtyp = AD_SPEL;
-            /* specific flags per race */
-            switch (rnd(8)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_ELF);
-                break;
-            case 3:
-                apply_race(mtmp, PM_GIANT);
-                break;
-            case 4:
-                apply_race(mtmp, PM_GNOME);
-                break;
-            case 5:
-                apply_race(mtmp, PM_HOBBIT);
-                break;
-            case 6:
-                apply_race(mtmp, PM_ORC);
+            if (race == PM_ORC || race == PM_ILLITHID)
                 rptr->ralign = -3;
-                break;
-            case 7:
-                apply_race(mtmp, PM_ILLITHID);
-                rptr->ralign = -3;
-                rptr->mattk[2].aatyp = AT_TENT;
-                rptr->mattk[2].adtyp = AD_DRIN;
-                rptr->mattk[2].damn = 2;
-                rptr->mattk[2].damd = 1;
-                break;
-            case 8:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
             break;
         default:
             break;
         }
     }
 
-    if (is_mercenary(ptr)) {
-        switch (mndx) {
-        case PM_SOLDIER:
-        case PM_SERGEANT:
-        case PM_LIEUTENANT:
-        case PM_WATCHMAN:
-        case PM_GUARD:
-        case PM_PRISON_GUARD:
-            switch (rnd(7)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_ELF);
-                break;
-            case 3:
-                apply_race(mtmp, PM_GNOME);
-                break;
-            case 4:
-                apply_race(mtmp, PM_ORC);
-                break;
-            case 5:
-                apply_race(mtmp, PM_CENTAUR);
-                break;
-            case 6:
-                apply_race(mtmp, PM_GIANT);
-                break;
-            case 7:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
-            break;
-        case PM_CAPTAIN:
-        case PM_WATCH_CAPTAIN:
-            switch (rnd(5)) {
-            case 1:
-                apply_race(mtmp, PM_DWARF);
-                break;
-            case 2:
-                apply_race(mtmp, PM_ELF);
-                break;
-            case 3:
-                apply_race(mtmp, PM_GNOME);
-                break;
-            case 4:
-                apply_race(mtmp, PM_GIANT);
-                break;
-            case 5:
-                apply_race(mtmp, PM_HUMAN);
-                break;
-            }
-            break;
-        default:
-            break;
-        }
-    }
+    if (is_mercenary(ptr))
+        apply_race(mtmp, rndrace(mndx));
 
     mtmp->mpeaceful = (mmflags & MM_ANGRY) ? FALSE : peace_minded(mtmp);
 

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -2151,6 +2151,7 @@ coord *cc;
 }
 
 extern void FDECL(get_mplname, (struct monst *, char *));
+extern void FDECL(init_mplayer_erac, (struct monst *));
 
 /*
  * called with [x,y] = coordinates;
@@ -2298,143 +2299,8 @@ int mmflags;
 
     /* set player monsters rank/title, race flags, and any
        appropriate flags that go along with their race */
-    if (is_mplayer(ptr)) {
-        char nam[PL_NSIZ];
-        int race;
-        struct erac *rptr;
-        get_mplname(mtmp, nam);
-        mtmp = christen_monst(mtmp, nam);
-
-        newerac(mtmp);
-        rptr = ERAC(mtmp);
-        rptr->mrace = ptr->mhflags;
-        rptr->ralign = ptr->maligntyp;
-        memcpy(rptr->mattk, ptr->mattk, sizeof(struct attack) * NATTK);
-
-        /* default player monster attacks */
-        rptr->mattk[0].aatyp = AT_WEAP;
-        rptr->mattk[0].adtyp = AD_PHYS;
-        rptr->mattk[0].damn = 1;
-        rptr->mattk[0].damd = 6;
-        rptr->mattk[1].aatyp = AT_WEAP;
-        rptr->mattk[1].adtyp = AD_SAMU;
-        rptr->mattk[1].damn = 1;
-        rptr->mattk[1].damd = 6;
-
-        race = rndrace(mndx);
-        apply_race(mtmp, race);
-
-        switch (mndx) {
-        case PM_ARCHEOLOGIST:
-            /* flags for all archeologists regardless of race */
-            rptr->mflags1 |= (M1_TUNNEL | M1_NEEDPICK);
-            if (race == PM_GNOME)
-                rptr->ralign = 0;
-            break;
-        case PM_BARBARIAN:
-            /* flags for all barbarians regardless of race */
-            rptr->mflags3 |= M3_BERSERK;
-            mtmp->mintrinsics |= MR_POISON;
-            if (race == PM_DWARF)
-                rptr->ralign = 0;
-            break;
-        case PM_CAVEMAN:
-        case PM_CAVEWOMAN:
-            /* flags for all cavepersons regardless of race */
-            /* cavepeople only have a single attack, but it does 2d4 */
-            rptr->mattk[0].damn = 2;
-            rptr->mattk[0].damd = 4;
-            rptr->mattk[0].adtyp = AD_SAMU;
-            rptr->mattk[1].aatyp = rptr->mattk[1].adtyp = 0;
-            rptr->mattk[1].damn = rptr->mattk[1].damd = 0;
-            if (race == PM_GNOME)
-                rptr->ralign = 0;
-            break;
-        case PM_CONVICT:
-            /* flags for all convicts regardless of race */
-            mtmp->mintrinsics |= MR_POISON;
-            break;
-        case PM_HEALER:
-            /* flags for all healers regardless of race */
-            rptr->mattk[0].adtyp = AD_SAMU;
-            rptr->mattk[1].aatyp = AT_MAGC;
-            rptr->mattk[1].adtyp = AD_CLRC;
-            mtmp->mintrinsics |= MR_POISON;
-            break;
-        case PM_INFIDEL:
-            /* flags for all infidels regardless of race */
-            rptr->mattk[0].adtyp = AD_SAMU;
-            rptr->mattk[1].aatyp = AT_MAGC;
-            rptr->mattk[1].adtyp = AD_SPEL;
-            mtmp->mintrinsics |= MR_FIRE;
-            break;
-        case PM_KNIGHT:
-            if (race == PM_ELF)
-                rptr->ralign = -3;
-            break;
-        case PM_MONK:
-            /* flags for all monks regardless of race */
-            rptr->mattk[0].adtyp = AD_SAMU;
-            rptr->mattk[1].aatyp = AT_KICK;
-            rptr->mattk[1].adtyp = AD_CLOB;
-            /* monks do 1d8 instead of 1d6 */
-            rptr->mattk[0].damn = rptr->mattk[1].damn = 1;
-            rptr->mattk[0].damd = rptr->mattk[1].damd = 8;
-            mtmp->mintrinsics |= (MR_POISON | MR_SLEEP);
-            break;
-        case PM_PRIEST:
-        case PM_PRIESTESS:
-            /* flags for all priests regardless of race */
-            rptr->mattk[0].adtyp = AD_SAMU;
-            rptr->mattk[1].aatyp = AT_MAGC;
-            rptr->mattk[1].adtyp = AD_CLRC;
-            if (race == PM_ORC || race == PM_ILLITHID)
-                rptr->ralign = -3;
-            break;
-        case PM_RANGER:
-            /* flags for all rangers regardless of race */
-            rptr->mflags3 |= M3_ACCURATE;
-            if (race == PM_HOBBIT)
-                rptr->ralign = 0;
-            break;
-        case PM_ROGUE:
-            /* flags for all rogues regardless of race */
-            rptr->mattk[0].adtyp = AD_SAMU;
-            rptr->mattk[1].adtyp = AD_SITM;
-            rptr->mflags3 |= M3_ACCURATE;
-            if (race == PM_HOBBIT)
-                rptr->ralign = 0;
-            break;
-        case PM_SAMURAI:
-            /* flags for all samurai regardless of race */
-            /* samurai do 1d8 instead of 1d6 */
-            rptr->mattk[0].damn = rptr->mattk[1].damn = 1;
-            rptr->mattk[0].damd = rptr->mattk[1].damd = 8;
-            break;
-        case PM_TOURIST:
-            /* nothing special based on role */
-            break;
-        case PM_VALKYRIE:
-            /* flags for all valkyrie regardless of race */
-            /* valkyries do 1d8 instead of 1d6 */
-            rptr->mattk[0].damn = rptr->mattk[1].damn = 1;
-            rptr->mattk[0].damd = rptr->mattk[1].damd = 8;
-            mtmp->mintrinsics |= MR_COLD;
-            if (race == PM_DWARF)
-                rptr->ralign = 3;
-            break;
-        case PM_WIZARD:
-            /* flags for all wizards regardless of race */
-            rptr->mattk[0].adtyp = AD_SAMU;
-            rptr->mattk[1].aatyp = AT_MAGC;
-            rptr->mattk[1].adtyp = AD_SPEL;
-            if (race == PM_ORC || race == PM_ILLITHID)
-                rptr->ralign = -3;
-            break;
-        default:
-            break;
-        }
-    }
+    if (is_mplayer(ptr))
+        init_mplayer_erac(mtmp);
 
     if (is_mercenary(ptr))
         apply_race(mtmp, rndrace(mndx));

--- a/src/mon.c
+++ b/src/mon.c
@@ -5531,11 +5531,11 @@ int raceidx;
 {
     register struct erac *rptr;
     register struct permonst *ptr = &mons[raceidx], *mptr = &mons[mtmp->mnum];
+    boolean init = FALSE;
 
     if (!mtmp || raceidx == NON_PM)
         return;
 
-    boolean init = FALSE;
     if (!has_erac(mtmp)) {
         newerac(mtmp);
         init = TRUE;

--- a/src/mon.c
+++ b/src/mon.c
@@ -5434,13 +5434,99 @@ struct monst *mon;
     mon->misc_worn_check |= I_SPECIAL;
 }
 
+int
+rndrace(mndx)
+int mndx;
+{
+#define NUM_RACES 9
+    int i, count = 0, race = NON_PM,
+        mraces[NUM_RACES] = { PM_HUMAN, PM_ELF, PM_DWARF, PM_GNOME, PM_ORC,
+                              PM_GIANT, PM_HOBBIT, PM_CENTAUR, PM_ILLITHID };
+    unsigned long permitted = MH_HUMAN;
+
+    switch (mndx) {
+    case PM_SOLDIER:
+    case PM_SERGEANT:
+    case PM_LIEUTENANT:
+    case PM_WATCHMAN:
+    case PM_GUARD:
+    case PM_PRISON_GUARD:
+        permitted |= (MH_CENTAUR | MH_ORC);
+        /* fallthru */
+    case PM_CAPTAIN:
+    case PM_WATCH_CAPTAIN:
+        permitted |= (MH_DWARF | MH_ELF | MH_GNOME | MH_GIANT);
+        break;
+    case PM_ARCHEOLOGIST:
+        permitted |= (MH_DWARF | MH_GNOME | MH_HOBBIT);
+        break;
+    case PM_BARBARIAN:
+    case PM_MONK:
+        permitted |= (MH_DWARF | MH_ORC | MH_GIANT | MH_CENTAUR);
+        break;
+    case PM_CAVEMAN:
+    case PM_CAVEWOMAN:
+        permitted |= (MH_DWARF | MH_GNOME | MH_GIANT);
+        break;
+    case PM_CONVICT:
+    case PM_HEALER:
+        permitted |= (MH_DWARF | MH_ORC | MH_GNOME | MH_HOBBIT);
+        break;
+    case PM_INFIDEL:
+        permitted |= (MH_ORC | MH_ILLITHID);
+        break;
+    case PM_KNIGHT:
+        permitted |= MH_ELF;
+        break;
+    case PM_PRIEST:
+    case PM_PRIESTESS:
+        permitted |=
+            (MH_DWARF | MH_ELF | MH_GIANT | MH_HOBBIT | MH_CENTAUR | MH_ORC);
+        break;
+    case PM_RANGER:
+        permitted |= (MH_ELF | MH_GNOME | MH_HOBBIT | MH_CENTAUR | MH_ORC);
+        break;
+    case PM_ROGUE:
+        permitted |= (MH_ELF | MH_HOBBIT | MH_ORC);
+        break;
+    case PM_SAMURAI:
+        permitted |= (MH_DWARF | MH_GIANT);
+        break;
+    case PM_TOURIST:
+        permitted |= MH_HOBBIT;
+        break;
+    case PM_VALKYRIE:
+        permitted |= (MH_DWARF | MH_GIANT | MH_CENTAUR);
+        break;
+    case PM_WIZARD:
+        permitted |=
+          (MH_DWARF | MH_ELF | MH_GIANT | MH_GNOME | MH_HOBBIT | MH_ILLITHID);
+        break;
+    default:
+        break;
+    }
+
+    for (i = 0; i < NUM_RACES; i++) {
+        if (permitted & mons[mraces[i]].mhflags) {
+            count++;
+            if (!rn2(count))
+                race = mraces[i];
+        }
+    }
+
+    return race;
+}
+
 void
 apply_race(mtmp, raceidx)
 struct monst *mtmp;
 int raceidx;
 {
     register struct erac *rptr;
-    register struct permonst *ptr = &mons[raceidx], *mptr = &mons[mtmp->m_id];
+    register struct permonst *ptr = &mons[raceidx], *mptr = &mons[mtmp->mnum];
+
+    if (!mtmp || raceidx == NON_PM)
+        return;
 
     boolean init = FALSE;
     if (!has_erac(mtmp)) {

--- a/src/mon.c
+++ b/src/mon.c
@@ -4786,14 +4786,21 @@ boolean msg;      /* "The oldmon turns into a newmon!" */
         return 0; /* still the same monster */
 
     mgender_from_permonst(mtmp, mdat);
-    /* Endgame mplayers start out as "Foo the Bar", but some of the
-     * titles are inappropriate when polymorphed, particularly into
-     * the opposite sex.  Player characters don't use ranks when
-     * polymorphed, so dropping rank for mplayers seems reasonable.
+    /* mplayers start out as "Foo the Bar", but some of the titles are
+     * inappropriate when polymorphed, particularly into the opposite sex.
+     * Player characters don't use ranks when polymorphed, so dropping rank
+     * for mplayers seems reasonable.
      */
-    if (In_endgame(&u.uz) && is_mplayer(olddata)
-        && has_mname(mtmp) && (p = strstr(MNAME(mtmp), " the ")) != 0)
+    if (is_mplayer(olddata) && has_mname(mtmp)
+        && (p = strstr(MNAME(mtmp), " the ")) != 0)
         *p = '\0';
+
+    /* handle racial characteristics -- remove an old race if it exists,
+     * and add a new random race if polymorphing into a racial monster */
+    if (has_erac(mtmp))
+        free_erac(mtmp);
+    if (is_racialmon(mdat))
+        apply_race(mtmp, rndrace(mtmp->mnum));
 
     if (mtmp->wormno) { /* throw tail away */
         wormgone(mtmp);

--- a/src/mplayer.c
+++ b/src/mplayer.c
@@ -6,6 +6,7 @@
 
 STATIC_DCL const char *NDECL(dev_name);
 void FDECL(get_mplname, (struct monst *, char *));
+void FDECL(init_mplayer_erac, (struct monst *));
 STATIC_DCL void FDECL(mk_mplayer_armor, (struct monst *, SHORT_P));
 
 /* These are the names of those who
@@ -102,6 +103,148 @@ char *nam;
     Strcat(nam, rank_of_mplayer((int) mtmp->m_lev, monsndx(mtmp->data),
                                 (boolean) mtmp->female));
 }
+
+void
+init_mplayer_erac(mtmp)
+struct monst *mtmp;
+{
+    char nam[PL_NSIZ];
+    int race;
+    struct erac *rptr;
+    int mndx = mtmp->mnum;
+    struct permonst *ptr = &mons[mndx];
+    get_mplname(mtmp, nam);
+    mtmp = christen_monst(mtmp, nam);
+
+    newerac(mtmp);
+    rptr = ERAC(mtmp);
+    rptr->mrace = ptr->mhflags;
+    rptr->ralign = ptr->maligntyp;
+    memcpy(rptr->mattk, ptr->mattk, sizeof(struct attack) * NATTK);
+
+    /* default player monster attacks */
+    rptr->mattk[0].aatyp = AT_WEAP;
+    rptr->mattk[0].adtyp = AD_PHYS;
+    rptr->mattk[0].damn = 1;
+    rptr->mattk[0].damd = 6;
+    rptr->mattk[1].aatyp = AT_WEAP;
+    rptr->mattk[1].adtyp = AD_SAMU;
+    rptr->mattk[1].damn = 1;
+    rptr->mattk[1].damd = 6;
+
+    race = rndrace(mndx);
+    apply_race(mtmp, race);
+
+    switch (mndx) {
+    case PM_ARCHEOLOGIST:
+        /* flags for all archeologists regardless of race */
+        rptr->mflags1 |= (M1_TUNNEL | M1_NEEDPICK);
+        if (race == PM_GNOME)
+            rptr->ralign = 0;
+        break;
+    case PM_BARBARIAN:
+        /* flags for all barbarians regardless of race */
+        rptr->mflags3 |= M3_BERSERK;
+        mtmp->mintrinsics |= MR_POISON;
+        if (race == PM_DWARF)
+            rptr->ralign = 0;
+        break;
+    case PM_CAVEMAN:
+    case PM_CAVEWOMAN:
+        /* flags for all cavepersons regardless of race */
+        /* cavepeople only have a single attack, but it does 2d4 */
+        rptr->mattk[0].damn = 2;
+        rptr->mattk[0].damd = 4;
+        rptr->mattk[0].adtyp = AD_SAMU;
+        rptr->mattk[1].aatyp = rptr->mattk[1].adtyp = 0;
+        rptr->mattk[1].damn = rptr->mattk[1].damd = 0;
+        if (race == PM_GNOME)
+            rptr->ralign = 0;
+        break;
+    case PM_CONVICT:
+        /* flags for all convicts regardless of race */
+        mtmp->mintrinsics |= MR_POISON;
+        break;
+    case PM_HEALER:
+        /* flags for all healers regardless of race */
+        rptr->mattk[0].adtyp = AD_SAMU;
+        rptr->mattk[1].aatyp = AT_MAGC;
+        rptr->mattk[1].adtyp = AD_CLRC;
+        mtmp->mintrinsics |= MR_POISON;
+        break;
+    case PM_INFIDEL:
+        /* flags for all infidels regardless of race */
+        rptr->mattk[0].adtyp = AD_SAMU;
+        rptr->mattk[1].aatyp = AT_MAGC;
+        rptr->mattk[1].adtyp = AD_SPEL;
+        mtmp->mintrinsics |= MR_FIRE;
+        break;
+    case PM_KNIGHT:
+        if (race == PM_ELF)
+            rptr->ralign = -3;
+        break;
+    case PM_MONK:
+        /* flags for all monks regardless of race */
+        rptr->mattk[0].adtyp = AD_SAMU;
+        rptr->mattk[1].aatyp = AT_KICK;
+        rptr->mattk[1].adtyp = AD_CLOB;
+        /* monks do 1d8 instead of 1d6 */
+        rptr->mattk[0].damn = rptr->mattk[1].damn = 1;
+        rptr->mattk[0].damd = rptr->mattk[1].damd = 8;
+        mtmp->mintrinsics |= (MR_POISON | MR_SLEEP);
+        break;
+    case PM_PRIEST:
+    case PM_PRIESTESS:
+        /* flags for all priests regardless of race */
+        rptr->mattk[0].adtyp = AD_SAMU;
+        rptr->mattk[1].aatyp = AT_MAGC;
+        rptr->mattk[1].adtyp = AD_CLRC;
+        if (race == PM_ORC || race == PM_ILLITHID)
+            rptr->ralign = -3;
+        break;
+    case PM_RANGER:
+        /* flags for all rangers regardless of race */
+        rptr->mflags3 |= M3_ACCURATE;
+        if (race == PM_HOBBIT)
+            rptr->ralign = 0;
+        break;
+    case PM_ROGUE:
+        /* flags for all rogues regardless of race */
+        rptr->mattk[0].adtyp = AD_SAMU;
+        rptr->mattk[1].adtyp = AD_SITM;
+        rptr->mflags3 |= M3_ACCURATE;
+        if (race == PM_DWARF)
+            rptr->ralign = 3;
+        break;
+    case PM_SAMURAI:
+        /* flags for all samurai regardless of race */
+        /* samurai do 1d8 instead of 1d6 */
+        rptr->mattk[0].damn = rptr->mattk[1].damn = 1;
+        rptr->mattk[0].damd = rptr->mattk[1].damd = 8;
+        break;
+    case PM_TOURIST:
+        /* nothing special based on role */
+        break;
+    case PM_VALKYRIE:
+        /* flags for all valkyrie regardless of race */
+        /* valkyries do 1d8 instead of 1d6 */
+        rptr->mattk[0].damn = rptr->mattk[1].damn = 1;
+        rptr->mattk[0].damd = rptr->mattk[1].damd = 8;
+        mtmp->mintrinsics |= MR_COLD;
+        break;
+    case PM_WIZARD:
+        /* flags for all wizards regardless of race */
+        rptr->mattk[0].adtyp = AD_SAMU;
+        rptr->mattk[1].aatyp = AT_MAGC;
+        rptr->mattk[1].adtyp = AD_SPEL;
+        if (race == PM_ORC || race == PM_ILLITHID)
+            rptr->ralign = -3;
+        break;
+    default:
+        break;
+    }
+}
+
 
 STATIC_OVL void
 mk_mplayer_armor(mon, typ)


### PR DESCRIPTION
Rather than having nested switch/case statements in makemon, rndrace selects a particular race that is valid for the monster index provided to it.

This enables makemon to be cleaned up a bit, and also permits easier expansion of races to new monster types in the future; I moved remaining switch/case statements dealing with player monster role initialization into a dedicated function so that they can be used elsewhere too (e.g. polymorphing a creature into a player monster?).