### PR TITLE
Rename rndrace to m_randrace

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1549,8 +1549,8 @@ E void FDECL(decide_to_shapeshift, (struct monst *, int));
 E boolean FDECL(vamp_stone, (struct monst *));
 E boolean FDECL(damage_mon, (struct monst*, int, int));
 E void FDECL(check_gear_next_turn, (struct monst *));
-E int FDECL(rndrace, (int));
-E void FDECL(apply_race, (struct monst *, int));
+E short FDECL(m_randrace, (SHORT_P));
+E void FDECL(apply_race, (struct monst *, SHORT_P));
 
 /* ### mondata.c ### */
 

--- a/include/mextra.h
+++ b/include/mextra.h
@@ -178,7 +178,7 @@ struct erid {
 /* racial characteristics */
 struct erac {
     unsigned long mrace;
-    int r_id;
+    short r_id;
     aligntyp ralign; 
     struct attack mattk[NATTK]; /* attacks matrix */
     unsigned long mflags1;

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -2343,7 +2343,7 @@ int mmflags;
         init_mplayer_erac(mtmp);
 
     if (is_mercenary(ptr))
-        apply_race(mtmp, rndrace(mndx));
+        apply_race(mtmp, m_randrace(mndx));
 
     mtmp->mpeaceful = (mmflags & MM_ANGRY) ? FALSE : peace_minded(mtmp);
 

--- a/src/mon.c
+++ b/src/mon.c
@@ -4800,7 +4800,7 @@ boolean msg;      /* "The oldmon turns into a newmon!" */
     if (has_erac(mtmp))
         free_erac(mtmp);
     if (is_racialmon(mdat))
-        apply_race(mtmp, rndrace(mtmp->mnum));
+        apply_race(mtmp, m_randrace(mtmp->mnum));
 
     if (mtmp->wormno) { /* throw tail away */
         wormgone(mtmp);
@@ -5441,14 +5441,14 @@ struct monst *mon;
     mon->misc_worn_check |= I_SPECIAL;
 }
 
-int
-rndrace(mndx)
-int mndx;
+short
+m_randrace(mndx)
+short mndx;
 {
-#define NUM_RACES 9
-    int i, count = 0, race = NON_PM,
-        mraces[NUM_RACES] = { PM_HUMAN, PM_ELF, PM_DWARF, PM_GNOME, PM_ORC,
-                              PM_GIANT, PM_HOBBIT, PM_CENTAUR, PM_ILLITHID };
+    int i, count = 0;
+    short race = NON_PM;
+    const short mraces[] = { PM_HUMAN, PM_ELF, PM_DWARF, PM_GNOME, PM_ORC,
+                           PM_GIANT, PM_HOBBIT, PM_CENTAUR, PM_ILLITHID, 0 };
     unsigned long permitted = MH_HUMAN;
 
     switch (mndx) {
@@ -5513,7 +5513,7 @@ int mndx;
         break;
     }
 
-    for (i = 0; i < NUM_RACES; i++) {
+    for (i = 0; mraces[i]; i++) {
         if (permitted & mons[mraces[i]].mhflags) {
             count++;
             if (!rn2(count))
@@ -5527,7 +5527,7 @@ int mndx;
 void
 apply_race(mtmp, raceidx)
 struct monst *mtmp;
-int raceidx;
+short raceidx;
 {
     register struct erac *rptr;
     register struct permonst *ptr = &mons[raceidx], *mptr = &mons[mtmp->mnum];

--- a/src/mplayer.c
+++ b/src/mplayer.c
@@ -130,7 +130,7 @@ struct monst *mtmp;
     rptr->mattk[1].damn = 1;
     rptr->mattk[1].damd = 6;
 
-    race = rndrace(mndx);
+    race = m_randrace(mndx);
     apply_race(mtmp, race);
 
     switch (mndx) {


### PR DESCRIPTION
The random race selection function for monsters was called 'rndrace',
which potentially could cause confusion since there was an existing
function for randomly selecting the player race called 'randrace' -- the
two are similar enough that I think it makes sense to change the name of
the monster function to be a bit clearer.

I also changed some of the mnum stuff from int to short, since that's
what is used for mnum in the monst struct.