### PR TITLE
Use player racial adjectives for monsters

### DIFF
--- a/include/mextra.h
+++ b/include/mextra.h
@@ -177,10 +177,10 @@ struct erid {
 
 /* racial characteristics */
 struct erac {
-    unsigned long mrace;
-    int r_id;
-    short rmnum;
-    aligntyp ralign; 
+    unsigned long mrace; /* equivalent to mhflags */
+    int r_id; /* index in races, used for races[r_id].adj */
+    short rmnum; /* index in mons, e.g. PM_HOBBIT */
+    aligntyp ralign; /* equivalent to maligntyp */
     struct attack mattk[NATTK]; /* attacks matrix */
     unsigned long mflags1;
     unsigned long mflags2;

--- a/include/mextra.h
+++ b/include/mextra.h
@@ -178,7 +178,8 @@ struct erid {
 /* racial characteristics */
 struct erac {
     unsigned long mrace;
-    short r_id;
+    int r_id;
+    short rmnum;
     aligntyp ralign; 
     struct attack mattk[NATTK]; /* attacks matrix */
     unsigned long mflags1;

--- a/src/apply.c
+++ b/src/apply.c
@@ -2001,7 +2001,7 @@ struct obj *obj;
         static const char you_buy_it[] = "You tin it, you bought it!";
 
         if (has_omonst(corpse) && has_erac(OMONST(corpse)))
-            can->corpsenm = ERAC(OMONST(corpse))->r_id;
+            can->corpsenm = ERAC(OMONST(corpse))->rmnum;
         else
             can->corpsenm = corpse->corpsenm;
         can->cursed = obj->cursed;

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -1058,7 +1058,7 @@ struct monst *mtmp;
     } else if (weap->spfx & SPFX_DCLAS) {
         return ((weap->mtype == (unsigned long) ptr->mlet)
                 || (has_erac(mtmp) && weap->mtype ==
-                    (unsigned long) mons[ERAC(mtmp)->r_id].mlet));
+                    (unsigned long) mons[ERAC(mtmp)->rmnum].mlet));
     } else if (weap->spfx & SPFX_DFLAG1) {
         return (((has_erac(mtmp) && (ERAC(mtmp)->mflags1 & weap->mtype))
                 || (ptr->mflags1 & weap->mtype) != 0L));

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -1831,24 +1831,9 @@ boolean called;
         Strcat(buf, "saddled ");
     if (has_erac(mtmp) && !type_is_pname(mdat)
         && (!(do_name && has_mname(mtmp)) || called)) {
-        if (racial_elf(mtmp))
-            Strcat(buf, "elven ");
-        else if (racial_dwarf(mtmp))
-            Strcat(buf, "dwarvish ");
-        else if (racial_orc(mtmp))
-            Strcat(buf, "orcish ");
-        else if (racial_gnome(mtmp))
-            Strcat(buf, "gnomish ");
-        else if (racial_hobbit(mtmp))
-            Strcat(buf, "hobbit ");
-        else if (racial_giant(mtmp))
-            Strcat(buf, "giant ");
-        else if (racial_illithid(mtmp))
-            Strcat(buf, "illithid ");
-        else if (racial_centaur(mtmp))
-            Strcat(buf, "centaurian ");
-        else if (racial_human(mtmp))
-            Strcat(buf, "human ");
+        int r_id = ERAC(mtmp)->r_id;
+        Sprintf(buf, "%s ", (r_id < 0) ? mons[ERAC(mtmp)->rmnum].mname
+                                       : races[r_id].adj);
     }
     has_adjectives = (buf[0] != '\0');
 

--- a/src/eat.c
+++ b/src/eat.c
@@ -470,7 +470,7 @@ boolean message;
 
     if (piece->otyp == CORPSE || piece->globby) {
         if (has_omonst(piece) && has_erac(OMONST(piece)))
-            cpostfx(ERAC(OMONST(piece))->r_id);
+            cpostfx(ERAC(OMONST(piece))->rmnum);
         else
             cpostfx(piece->corpsenm);
     } else
@@ -611,7 +611,7 @@ int *dmg_p; /* for dishing out extra damage in lieu of Int loss */
         /* targetting another mind flayer or your own underlying species
            is cannibalism */
         if (has_erac(mdef))
-            (void) maybe_cannibal(ERAC(mdef)->r_id, TRUE);
+            (void) maybe_cannibal(ERAC(mdef)->rmnum, TRUE);
         else
             (void) maybe_cannibal(monsndx(pd), TRUE);
 
@@ -1753,7 +1753,7 @@ struct obj *otmp;
 
         boolean cannibal;
         if (has_omonst(otmp) && has_erac(OMONST(otmp)))
-            cannibal = maybe_cannibal(ERAC(OMONST(otmp))->r_id, FALSE);
+            cannibal = maybe_cannibal(ERAC(OMONST(otmp))->rmnum, FALSE);
         else
             cannibal = maybe_cannibal(mnum, FALSE);
 
@@ -1905,7 +1905,7 @@ boolean already_partly_eaten;
 
     if (otmp->otyp == CORPSE || otmp->globby) {
         if (has_omonst(otmp) && has_erac(OMONST(otmp)))
-            cprefx(ERAC(OMONST(otmp))->r_id);
+            cprefx(ERAC(OMONST(otmp))->rmnum);
         else
             cprefx(context.victual.piece->corpsenm);
         if (!context.victual.piece || !context.victual.eating) {

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -2341,8 +2341,7 @@ int mmflags;
        appropriate flags that go along with their race */
     if (is_mplayer(ptr))
         init_mplayer_erac(mtmp);
-
-    if (is_mercenary(ptr))
+    else if (is_mercenary(ptr))
         apply_race(mtmp, m_randrace(mndx));
 
     mtmp->mpeaceful = (mmflags & MM_ANGRY) ? FALSE : peace_minded(mtmp);

--- a/src/mon.c
+++ b/src/mon.c
@@ -32,6 +32,7 @@ STATIC_DCL void FDECL(migrate_mon, (struct monst *, XCHAR_P, XCHAR_P));
 STATIC_DCL boolean FDECL(ok_to_obliterate, (struct monst *));
 STATIC_DCL void FDECL(deal_with_overcrowding, (struct monst *));
 STATIC_DCL void FDECL(icequeenrevive, (struct monst *));
+STATIC_DCL int FDECL(pm_to_race, (SHORT_P));
 
 /* note: duplicated in dog.c */
 #define LEVEL_SPECIFIC_NOCORPSE(mdat) \
@@ -5441,6 +5442,19 @@ struct monst *mon;
     mon->misc_worn_check |= I_SPECIAL;
 }
 
+STATIC_OVL int
+pm_to_race(mndx)
+short mndx;
+{
+    int i;
+    for (i = 0; races[i].adj; i++) {
+        if (races[i].malenum == mndx || races[i].femalenum == mndx)
+            return i;
+    }
+
+    return NON_PM;
+}
+
 short
 m_randrace(mndx)
 short mndx;
@@ -5552,8 +5566,9 @@ short raceidx;
     }
 
     mtmp->mintrinsics |= ptr->mresists;
+    rptr->r_id = pm_to_race(raceidx);
     rptr->mrace = ptr->mhflags;
-    rptr->r_id = raceidx;
+    rptr->rmnum = raceidx;
     /* racial mflags are cumulative with mflags from the base monster, rather
      * than overwriting them entirely */
     rptr->mflags1 |= ptr->mflags1;

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -1650,24 +1650,9 @@ unsigned cxn_flags; /* bitmask of CXN_xxx values */
         mtmp = OMONST(otmp);
 
         if (has_erac(mtmp)) {
-            if (racial_elf(mtmp))
-                Strcat(mrace, "elven ");
-            else if (racial_dwarf(mtmp))
-                Strcat(mrace, "dwarvish ");
-            else if (racial_orc(mtmp))
-                Strcat(mrace, "orcish ");
-            else if (racial_gnome(mtmp))
-                Strcat(mrace, "gnomish ");
-            else if (racial_hobbit(mtmp))
-                Strcat(mrace, "hobbit ");
-            else if (racial_giant(mtmp))
-                Strcat(mrace, "giant ");
-            else if (racial_illithid(mtmp))
-                Strcat(mrace, "illithid ");
-            else if (racial_centaur(mtmp))
-                Strcat(mrace, "centaurian ");
-            else if (racial_human(mtmp))
-                Strcat(mrace, "human ");
+            int r_id = ERAC(mtmp)->r_id;
+            Sprintf(mrace, "%s ", (r_id < 0) ? mons[ERAC(mtmp)->rmnum].mname
+                                             : races[r_id].adj);
         }
     }
 


### PR DESCRIPTION
This eliminates some long if/else chains in do_name.c and objnam.c by
referring to the adjective in races[].  For monsters with "races" not
available to the player (since any PM index can be applied as a monster
race), fall back on the name of the monster without trying to convert it
into an adjective -- e.g. "the newt centaur punches you!" for a centaur
that is a racial newt, compared to "the centaurian newt punches you" 
for a newt that is a racial centaur.