### PR TITLE
Handle M2_NEUTER monsters when using a stethoscope

### DIFF
--- a/src/priest.c
+++ b/src/priest.c
@@ -1258,7 +1258,7 @@ struct monst *mtmp;
                                (SUPPRESS_IT | SUPPRESS_INVISIBLE), FALSE));
 
     pline("Status of %s (%s, %s):  Level %d  HP %d(%d)  AC %d%s.", monnambuf,
-          mtmp->female ? "female" : "male", align_str(alignment),
+          genders[gender(mtmp)].adj, align_str(alignment),
           mtmp->m_lev, mtmp->mhp, mtmp->mhpmax, find_mac(mtmp), info);
 }
 
@@ -1267,6 +1267,8 @@ void
 ustatusline()
 {
     char info[BUFSZ];
+    int gend = (Upolyd && is_neuter(youmonst.data)) ? 2
+                                                    : (flags.female ? 1 : 0);
 
     info[0] = '\0';
     if (Sick) {
@@ -1331,7 +1333,7 @@ ustatusline()
     }
 
     pline("Status of %s (%s, %s):  Level %d  HP %d(%d)  AC %d%s.", plname,
-          flags.female ? "female" : "male", piousness(FALSE, align_str(u.ualign.type)),
+          genders[gend].adj, piousness(FALSE, align_str(u.ualign.type)),
           Upolyd ? mons[u.umonnum].mlevel : u.ulevel, Upolyd ? u.mh : u.uhp,
           Upolyd ? u.mhmax : u.uhpmax, u.uac, info);
 }


### PR DESCRIPTION
Stethoscopes now print the gender of the monster they're applied to, but
would default to male for cases where a monster had the M2_NEUTER flag
set; using genders[].adj makes it simpler to handle this case properly
for monsters as well as the player (when polymorphed into a neuter mon).