### PR TITLE
Mark intrinsic-granting corpses as treats

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -723,6 +723,7 @@ E void FDECL(food_substitution, (struct obj *, struct obj *));
 E void FDECL(eating_conducts, (struct permonst *));
 E int FDECL(eat_brains, (struct monst *, struct monst *, BOOLEAN_P, int *));
 E void NDECL(fix_petrification);
+E boolean FDECL(can_give_new_mintrinsic, (struct permonst *, struct monst *));
 E boolean FDECL(should_givit, (int, struct permonst *));
 E int FDECL(corpse_intrinsic, (struct permonst *));
 E void FDECL(consume_oeaten, (struct obj *, int));

--- a/src/dog.c
+++ b/src/dog.c
@@ -878,7 +878,9 @@ register struct obj *obj;
             else if (is_shapeshifter(fptr))
                 return starving ? ACCFOOD : MANFOOD;
             else if (vegan(fptr))
-                return herbi ? CADAVER : MANFOOD;
+                return herbi ? (can_give_new_mintrinsic(fptr, mon) ? DOGFOOD
+                                                                   : CADAVER)
+                             : MANFOOD;
             /* most humanoids will avoid cannibalism unless starving;
                arbitrary: elves won't eat other elves even then */
             else if (humanoid(mptr) && same_race(mptr, fptr)
@@ -886,7 +888,9 @@ register struct obj *obj;
                          && fptr->mlet != S_ORC && fptr->mlet != S_OGRE))
                 return (starving && carni && !racial_elf(mon)) ? ACCFOOD : TABU;
             else
-                return carni ? CADAVER : MANFOOD;
+                return carni ? (can_give_new_mintrinsic(fptr, mon) ? DOGFOOD
+                                                                   : CADAVER)
+                             : MANFOOD;
         case CLOVE_OF_GARLIC:
             return (is_undead(mptr) || is_vampshifter(mon))
                       ? TABU

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -616,7 +616,7 @@ struct permonst* ptr;
         /* suppress message if mtmp already has this
            resistance via another source (worn object,
            or natively has this intrinsic/resistance) */
-        if (!((mtmp->mextrinsics || mtmp->data->mresists) & intrinsic))
+        if (!((mtmp->mextrinsics | mtmp->data->mresists) & intrinsic))
             pline(msg, Monnam(mtmp));
     }
 }

--- a/src/eat.c
+++ b/src/eat.c
@@ -880,6 +880,26 @@ register struct permonst *ptr;
     return res;
 }
 
+boolean
+can_give_new_mintrinsic(ptr, mon)
+struct permonst *ptr;
+struct monst *mon;
+{
+#define mon_has_intrinsic(intrinsic, mon) \
+    (((mon)->mintrinsics | (mon)->data->mresists) & intrinsic)
+    int i;
+    for (i = 1; i <= STONE_RES; i++) {
+        if (intrinsic_possible(i, ptr) && !mon_has_intrinsic((1 << i), mon)) {
+            return TRUE;
+        }
+    }
+    if (intrinsic_possible(TELEPAT, ptr)
+        && !(mon_has_intrinsic(MR2_TELEPATHY, mon) || telepathic(mon->data)))
+        return TRUE;
+
+    return FALSE;
+}
+
 /* The "do we or do we not give the intrinsic" logic from givit(), extracted
  * into its own function. Depends on the monster's level and the type of
  * intrinsic it is trying to give you.


### PR DESCRIPTION
Because pets won't eat treats immediately as they do in vanilla, this does not mean that pets will bound past the hero to steal intrinsic-granting corpses from the player; instead the gameplay effect is basically just to bump corpses that grant intrinsics to the top of the line when a pet is hungry and deciding between several potential sources of food.

Also corrects a typo in the "the black dragon eats a black dragon corpse. The black dragon looks very firm" fix that led to it not working.