### PR TITLE
Magic 8-Ball tweaks

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -460,7 +460,7 @@ doread()
             return 0;
         }
         if (flags.verbose) {
-            pline("You turn over the Magic 8-Ball and read:");
+            pline("You turn over %s and read:", the(xname(scroll)));
         }
         pline("\"%s\".", eightball_msgs[rn2(SIZE(eightball_msgs))]);
         if (!u.uconduct.literate++) {

--- a/src/read.c
+++ b/src/read.c
@@ -440,77 +440,33 @@ doread()
                     "became literate by reading the divine signature of Heimdallr");
         return 1;
     } else if (scroll->oartifact == ART_MAGIC___BALL) {
-        if (Blind)
-            You("feel the smooth plastic window.");
-        else if (flags.verbose)
-            pline("The Magic 8-Ball replies:");
-        switch (rn2(20)) {
-            case 0:
-                pline("It is certain.");
-                break;
-            case 1:
-                pline("It is decidedly so.");
-                break;
-            case 2:
-                pline("Without a doubt.");
-                break;
-            case 3:
-                pline("Yes - definitely.");
-                break;
-            case 4:
-                pline("You may rely on it.");
-                break;
-            case 5:
-                pline("As I see it, yes.");
-                break;
-            case 6:
-                pline("Most likely.");
-                break;
-            case 7:
-                pline("Outlook good.");
-                break;
-            case 8:
-                pline("Yes.");
-                break;
-            case 9:
-                pline("Signs point to yes.");
-                break;
-            case 10:
-                pline("Reply hazy, try again.");
-                break;
-            case 11:
-                pline("Ask again later.");
-                break;
-            case 12:
-                pline("Better not tell you now.");
-                break;
-            case 13:
-                pline("Cannot predict now.");
-                break;
-            case 14:
-                pline("Concentrate and ask again.");
-                break;
-            case 15:
-                pline("Don't count on it.");
-                break;
-            case 16:
-                pline("My reply is no.");
-                break;
-            case 17:
-                pline("My sources say no.");
-                break;
-            case 18:
-                pline("Outlook not so good.");
-                break;
-            case 19:
-                pline("Very doubtful.");
-                break;
-            default:
-                break;
+        static const char *eightball_msgs[] = {
+            /* Positive */
+            "Yes", "Signs point to yes", "As I see it, yes",
+            "Yes - definitely", "It is certain", "It is decidedly so",
+            "Without a doubt", "You may rely on it", "Most likely",
+            "Outlook good",
+            /* Noncommital */
+            "Reply hazy, try again", "Ask again later",
+            "Better not tell you now", "Cannot predict now",
+            "Concentrate and ask again",
+            /* Negative */ 
+            "Don't count on it", "Outlook not so good", "Very doubtful",
+            "My reply is no", "My sources say no",
+        };
+
+        if (Blind) {
+            You("feel only a smooth plastic window.");
+            return 0;
         }
-        if (!u.uconduct.literate++)
+        if (flags.verbose) {
+            pline("You turn over the Magic 8-Ball and read:");
+        }
+        pline("\"%s\".", eightball_msgs[rn2(SIZE(eightball_msgs))]);
+        if (!u.uconduct.literate++) {
             livelog_write_string(LL_CONDUCT,
                     "became literate by reading the Magic 8-Ball");
+        }
         return 1;
     } else if (scroll->otyp == CANDY_BAR) {
         static const char *wrapper_msgs[] = {


### PR DESCRIPTION
Instead of using a switch/case and listing each possible result/answer on its own, select at random from an array of all the possible 8-ball responses.

Also fixes a bug where blind heroes could still read the responses from the 8-ball, despite getting feedback suggesting that this ought to be impossible.

~I also changed the responses to use ALL CAPS, which is how the responses in real-life Magic 8-Balls [are formatted](https://user-images.githubusercontent.com/40038830/109662731-5edfa700-7b39-11eb-9fc9-16b0fd306909.jpg), but I understand that this might be a point of contention so I split that into a separate commit -- feel free to cherry-pick only the first and last commits (b00c957c1f07ec359be0c3fa5f669652b689942d and 4aadfddef69a2e9f98505d6aea64a5e84aba3d99) and ignore the second, which is where the formatting is changed.  Or just let me know and I'll update and force-push the branch so that the PR only includes b00c957c1f07ec359be0c3fa5f669652b689942d and 4aadfddef69a2e9f98505d6aea64a5e84aba3d99.~