### PR TITLE
Guaranteed artifact gifts

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -108,6 +108,7 @@ E void NDECL(mkot_trap_warn);
 E boolean FDECL(is_magic_key, (struct monst *, struct obj *));
 E struct obj *FDECL(has_magic_key, (struct monst *));
 E boolean FDECL(wielding_artifact, (int));
+E boolean NDECL(awaiting_guaranteed_gift);
 
 /* ### attrib.c ### */
 

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -3473,4 +3473,26 @@ int art;
             || (u.twoweap && uswapwep->oartifact == art));
 }
 
+boolean
+awaiting_guaranteed_gift()
+{
+    int m;
+    struct artifact *a;
+    for (m = 1, a = &artilist[m]; a->otyp; a++, m++) {
+        if (artiexist[m])
+            continue;
+        if (a->spfx & SPFX_NOGEN)
+            continue;
+        /* uses the same criteria as mk_artifact */
+        if (Role_if(a->role)
+            && (a->alignment == u.ualign.type || a->alignment == A_NONE)
+            && (a->race == NON_PM || !race_hostile(&mons[a->race]))
+            && (!(Race_if(PM_GIANT) && (a->mtype & MH_GIANT)))
+            && (!(Role_if(PM_PRIEST) && (is_slash(a) || is_pierce(a))))) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 /*artifact.c*/

--- a/src/pray.c
+++ b/src/pray.c
@@ -2091,22 +2091,29 @@ dosacrifice()
              * The chance goes down as the number of artifacts goes up.
              *
              * From SporkHack (heavily modified):
-             * The player can also get handed just a plain old hunk of weaponry
-             * or piece of armor, but it will be blessed, +3 to +5, fire/rustproof, and
-             * if it's a weapon, it'll be in one of the player's available skill
-             * slots. The lower level you are, the more likely it is that you'll
-             * get a hunk of ordinary junk rather than an artifact.
+             * The player can also get handed just a plain old hunk of
+             * weaponry or piece of armor, but it will be blessed, +3 to +5,
+             * fire/rustproof, and if it's a weapon, it'll be in one of the
+             * player's available skill slots. The lower level you are, the
+             * more likely it is that you'll get a hunk of ordinary junk
+             * rather than an artifact.
              *
              * Note that no artifact is guaranteed; it's still subject to the
-             * chances of generating one of those in the first place. These are
-             * just the chances that an artifact will even be considered as a gift.
+             * chances of generating one of those in the first place. These
+             * are just the chances that an artifact will even be considered
+             * as a gift.
              *
-             * level  4: 10% chance  level  9: 20% chance  level 12: 30% chance
-             * level 14: 40% chance  level 17: 50% chance  level 19: 60% chance
-             * level 21: 70% chance  level 23: 80% chance  level 24: 90% chance
+             * If your role has a guaranteed first sacrifice gift, you will
+             * not receive a non-artifact item as a gift until you've gotten
+             * your guaranteed artifact.
+             *
+             * level  4: 10% chance level  9: 20% chance level 12: 30% chance
+             * level 14: 40% chance level 17: 50% chance level 19: 60% chance
+             * level 21: 70% chance level 23: 80% chance level 24: 90% chance
              * level 26 or greater: 100% chance
              */
-            if (rn2(10) >= (int) ((nchance * nchance) / 100)) {
+            if (!awaiting_guaranteed_gift()
+                && rn2(10) >= (int) ((nchance * nchance) / 100)) {
                 if (u.uluck >= 0 && !rn2(6 + (2 * u.ugifts))) {
                     int typ, ncount = 0;
                     if (rn2(2)) { /* Making a weapon */


### PR DESCRIPTION
Roles which have role-specific sacrifice gifts will not receive normal
items as sacrifice gifts until they have received their initial
artifact; this means that a role with a guaranteed sacrifice gift will
be certain to get an artifact as their initial gift, but will not be
able to sacrifice for non-artifact gear if they're too low-level to get
their first artifact gift.