### PR TITLE
Use erac for racial priests and shopkeepers

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -444,6 +444,10 @@
      && (glyph) < (GLYPH_WARNING_OFF + WARNCOUNT))
 
 #define use_racial_glyph(mon) \
-    (has_erac(mon) && !is_mplayer((mon)->data) && !is_mercenary((mon)->data))
+    (has_erac(mon) \
+     && !is_mplayer((mon)->data) \
+     && !is_mercenary((mon)->data) \
+     && !((mon)->data == &mons[PM_HIGH_PRIEST] \
+         && Is_astralevel(&u.uz)))
 
 #endif /* DISPLAY_H */

--- a/include/extern.h
+++ b/include/extern.h
@@ -1267,6 +1267,7 @@ E void FDECL(set_mimic_sym, (struct monst *));
 E int FDECL(mbirth_limit, (int));
 E void FDECL(mimic_hit_msg, (struct monst *, SHORT_P));
 E void FDECL(mkmonmoney, (struct monst *, long));
+E void FDECL(setup_mon_inventory, (struct monst *));
 E int FDECL(bagotricks, (struct obj *, BOOLEAN_P, int *));
 E boolean FDECL(propagate, (int, BOOLEAN_P, BOOLEAN_P));
 E boolean FDECL(usmellmon, (struct permonst *));
@@ -1565,6 +1566,7 @@ E boolean FDECL(vamp_stone, (struct monst *));
 E boolean FDECL(damage_mon, (struct monst*, int, int));
 E void FDECL(check_gear_next_turn, (struct monst *));
 E int FDECL(pm_to_race, (SHORT_P));
+E short FDECL(align_randrace, (ALIGNTYP_P));
 E short FDECL(m_randrace, (SHORT_P));
 E void FDECL(apply_race, (struct monst *, SHORT_P));
 

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -1792,6 +1792,7 @@ boolean called;
             name += 4;
         return strcpy(buf, name);
     }
+
     /* an "aligned priest" not flagged as a priest or minion should be
        "priest" or "priestess" (normally handled by priestname()) */
     if (mdat == &mons[PM_ALIGNED_PRIEST])
@@ -1814,11 +1815,14 @@ boolean called;
             return buf;
         }
         Strcat(buf, shkname(mtmp));
-        if (mdat == &mons[PM_SHOPKEEPER] && !do_invis)
-            return buf;
         Strcat(buf, " the ");
         if (do_invis)
             Strcat(buf, "invisible ");
+        if (has_erac(mtmp)) {
+            int r_id = ERAC(mtmp)->r_id;
+            Sprintf(eos(buf), "%s ", (r_id < 0) ? mons[ERAC(mtmp)->rmnum].mname
+                                                : races[r_id].adj);
+        }
         Strcat(buf, pm_name);
         return buf;
     }
@@ -1835,6 +1839,8 @@ boolean called;
         && !Hallucination)
         Strcat(buf, "barded ");
     if (has_erac(mtmp) && !type_is_pname(mdat)
+        /* don't reveal high priest race too early */
+        && mdat != &mons[PM_HIGH_PRIEST]
         && (!(do_name && has_mname(mtmp)) || called)) {
         int r_id = ERAC(mtmp)->r_id;
         Sprintf(eos(buf), "%s ", (r_id < 0) ? mons[ERAC(mtmp)->rmnum].mname

--- a/src/mon.c
+++ b/src/mon.c
@@ -5343,7 +5343,9 @@ kill_genocided_monsters()
         mndx = monsndx(mtmp->data);
         kill_cham = (mtmp->cham >= LOW_PM
                      && (mvitals[mtmp->cham].mvflags & G_GENOD));
-        if ((mvitals[mndx].mvflags & G_GENOD) || kill_cham) {
+        if ((mvitals[mndx].mvflags & G_GENOD) || kill_cham
+            || (has_erac(mtmp)
+                && mvitals[ERAC(mtmp)->rmnum].mvflags & G_GENOD)) {
             if (mtmp->cham >= LOW_PM && !kill_cham)
                 (void) newcham(mtmp, (struct permonst *) 0, FALSE, FALSE);
             else

--- a/src/mon.c
+++ b/src/mon.c
@@ -5820,7 +5820,8 @@ short mndx;
     }
 
     for (i = 0; mraces[i]; i++) {
-        if (permitted & mons[mraces[i]].mhflags) {
+        if (permitted & mons[mraces[i]].mhflags
+            && !(mvitals[mraces[i]].mvflags & G_GONE)) {
             count++;
             if (!rn2(count))
                 race = mraces[i];
@@ -5839,7 +5840,7 @@ short raceidx;
     register struct permonst *ptr = &mons[raceidx], *mptr = &mons[mtmp->mnum];
     boolean init = FALSE;
 
-    if (!mtmp || raceidx == NON_PM)
+    if (!mtmp || raceidx == NON_PM || mvitals[raceidx].mvflags & G_GONE)
         return;
 
     if (!has_erac(mtmp)) {

--- a/src/shk.c
+++ b/src/shk.c
@@ -20,15 +20,8 @@ STATIC_DCL void FDECL(kops_gone, (BOOLEAN_P));
 #define IS_SHOP(x) (rooms[x].rtype >= SHOPBASE)
 
 #define match_shkrace(mon) \
-    ((urace.malenum == (mon)->mnum) \
-     || (urace.malenum == PM_ELF && is_elf(mon->data)) \
-     || (urace.malenum == PM_DWARF && is_dwarf(mon->data)) \
-     || (urace.malenum == PM_ORC && is_orc(mon->data)) \
-     || (urace.malenum == PM_GNOME && is_gnome(mon->data)) \
-     || (urace.malenum == PM_ILLITHID && is_illithid(mon->data)) \
-     || (urace.malenum == PM_CENTAUR && is_centaur(mon->data)) \
-     || (urace.malenum == PM_HUMAN && is_human(mon->data)) \
-     || (urace.malenum == PM_GIANT && is_giant(mon->data)))
+    ((has_erac(mon) && Race_if(ERAC(mon)->rmnum)) \
+     || Race_if((mon)->mnum))
 
 #define muteshk(shkp)                       \
     ((shkp)->msleeping || !(shkp)->mcanmove \
@@ -53,7 +46,7 @@ STATIC_DCL void FDECL(clear_unpaid_obj, (struct monst *, struct obj *));
 STATIC_DCL void FDECL(clear_unpaid, (struct monst *, struct obj *));
 STATIC_DCL long FDECL(check_credit, (long, struct monst *));
 STATIC_DCL void FDECL(pay, (long, struct monst *));
-STATIC_DCL void FDECL(shk_racial_adjustments, (short, long *, long *));
+STATIC_DCL void FDECL(shk_racial_adjustments, (SHORT_P, long *, long *));
 STATIC_DCL long FDECL(get_cost, (struct obj *, struct monst *));
 STATIC_DCL long FDECL(set_cost, (struct obj *, struct monst *));
 STATIC_DCL const char *FDECL(shk_embellish, (struct obj *, long));
@@ -2354,12 +2347,13 @@ register struct monst *shkp; /* if angry, impose a surcharge */
     /* possible additional surcharges based on shk race, if one was passed in */
     if (shkp) {
         long numer, denom;
-        shk_racial_adjustments(shkp->mnum, &numer, &denom);
+        shk_racial_adjustments(has_erac(shkp) ? ERAC(shkp)->rmnum : shkp->mnum,
+                               &numer, &denom);
         multiplier *= numer;
         divisor *= denom;
 
         /* professional courtesy if nonhuman */
-        if (!is_human(shkp->data) && match_shkrace(shkp))
+        if (!racial_human(shkp) && match_shkrace(shkp))
             divisor *= 2;
     }
 
@@ -2585,7 +2579,8 @@ register struct monst *shkp;
     /* possible additional surcharges based on shk race, if one was passed in */
     if (shkp) {
         long numer, denom;
-        shk_racial_adjustments(shkp->mnum, &numer, &denom);
+        shk_racial_adjustments(has_erac(shkp) ? ERAC(shkp)->rmnum : shkp->mnum,
+                               &numer, &denom);
 
         /* Illithids are very reticent to let their books go and thus they
          * charge exorbitantly for them. However, they do want to acquire more
@@ -2601,7 +2596,7 @@ register struct monst *shkp;
         }
 
         /* professional courtesy if nonhuman, but not _that_ much */
-        if (!is_human(shkp->data) && match_shkrace(shkp))
+        if (!racial_human(shkp) && match_shkrace(shkp))
             multiplier *= 4L, divisor *= 3L;
     }
 

--- a/src/shknam.c
+++ b/src/shknam.c
@@ -747,46 +747,10 @@ int shp_indx;
         break;
     }
 
-    /* if we picked a specific monster, use that... */
-    if (srace) {
-        /* on the odd chance that it hit one that was genoed, leave it a normal shk */
-        if (!(mvitals[srace].mvflags & G_GONE)) {
-            mdat = &mons[srace];
-            shk->mnum = srace;
-            set_mon_data(shk, mdat);
-        }
-    } else {
-        srace = rnd(6);
-        if (srace) {
-            switch (srace) {
-            case 1:
-                mdat = &mons[PM_ELF];
-                shk->mnum = PM_ELF;
-                break;
-            case 2:
-                mdat = &mons[PM_DWARF];
-                shk->mnum = PM_DWARF;
-                break;
-            case 3:
-                mdat = &mons[PM_ORC];
-                shk->mnum = PM_ORC;
-                break;
-            case 4:
-                mdat = &mons[PM_GNOME];
-                shk->mnum = PM_GNOME;
-                break;
-            case 5:
-                mdat = &mons[PM_GIANT];
-                shk->mnum = PM_GIANT;
-                break;
-            case 6:
-                mdat = &mons[PM_HUMAN];
-                shk->mnum = PM_HUMAN;
-                break;
-            }
-        set_mon_data(shk, &mons[shk->mnum]);
-        }
+    if (!srace) {
+        srace = m_randrace(monsndx(shk->data));
     }
+    apply_race(shk, srace);
 
     shk->isshk = shk->mpeaceful = 1;
     set_malign(shk);


### PR DESCRIPTION
Update racial priest and shopkeeper implementation to use the 'erac'
struct that was already used for racial player monsters and soldiers.
High priests on Astral will have a race defined based on their alignment
like other priests do, but will continue to use @ instead of a racial
glyph to avoid revealing their alignment too early.  "Renegade" and
other wandering priests can now have a race defined, which makes for
some level of greater enemy variety (at least superficially) on Astral
and in the Sanctum.  Priests with grudges/racial enmities will only
fight each other if they follow different gods.

Priest races are based on their alignment (should be the same valid
combinations as before but the actual mechanism was refactored to use a
similar system as m_randrace); shopkeeper races are based on their type
of shop -- I didn't touch the shopkeeper race selection code at all
beyond the part where the race is actually applied.