### PR TITLE
Provide more detailed farlook armor descriptions

### DIFF
--- a/src/pager.c
+++ b/src/pager.c
@@ -319,8 +319,25 @@ int x, y;
 
     if (canseemon(mtmp) && !Blind) {
         if (!Hallucination) {
-            if (which_armor(mtmp, W_ARMOR))
-                Strcat(buf, ", wearing armor");
+            if (mtmp->misc_worn_check & W_ARMOR) {
+                int base_ac = 0, arm_ct = 0;
+                long atype;
+                struct obj *otmp;
+
+                for (atype = W_ARM; atype & W_ARMOR; atype <<= 1) {
+                    if (!(otmp = which_armor(mtmp, atype)))
+                        continue;
+                    /* don't count armor->spe, since this represents only what
+                     * the hero can see from afar -- monster with +8 gloves
+                     * will still seem "lightly armored" from a distance */
+                    base_ac += ARM_BONUS(otmp) - otmp->spe;
+                    arm_ct++;
+                }
+
+                Sprintf(eos(buf), ", wearing %s%sarmor", 
+                        arm_ct > 4 ? "full " : arm_ct < 3 ? "some " : "",
+                        base_ac > 9 ? "heavy " : base_ac < 6 ? "light " : "");
+            }
             if (MON_WEP(mtmp))
                 Sprintf(eos(buf), ", wielding %s",
                         ansimpleoname(MON_WEP(mtmp)));


### PR DESCRIPTION
Instead of just adding 'wearing armor' when farlooking a monster wearing
any kind of armor -- meaning a creature wearing a pair of gloves is
described in exactly the same way as a creature in full plate mail --
include some additional details about the number of pieces of armor and
the monster's total apparent AC (not factoring in the enchantment on the
armor, since that would not be visible with the naked eye).

This way the monster wearing gloves goes from "wearing armor" to
"wearing some light armor", while the monster in full plate mail is now
"wearing full heavy armor", making the distinction clear without giving
away too many details that would normally require probing/a stethoscope.

It may be worth revisiting the exact thresholds for the different
modifiers later on, since they were basically pulled out of thin air
rather than being based on any objective criteria.
