### PR TITLE
Fix some small monster inventory init bugs

### DIFF
--- a/src/makemon.c
+++ b/src/makemon.c
@@ -564,10 +564,11 @@ unsigned short chance;
 
             if (trop->trclass == COIN_CLASS) {
                 /* no "blessed" or "identified" money */
-                obj->quan = u.umoney0;
+                obj->quan = trop->trquan;
+                trop->trquan = 1;
             } else {
                 obj->cursed = (trop->trbless == CURSED);
-                if (obj->opoisoned && u.ualign.type > A_CHAOTIC)
+                if (obj->opoisoned && mon_aligntyp(mtmp) > A_CHAOTIC)
                     obj->opoisoned = 0;
                 if (obj->oclass == WEAPON_CLASS
                     || obj->oclass == TOOL_CLASS) {

--- a/src/worn.c
+++ b/src/worn.c
@@ -690,7 +690,7 @@ boolean creation;
         m_dowear_type(mon, W_ARMU, creation, FALSE);
     /* treating small as a special case allows
        hobbits, gnomes, and kobolds to wear cloaks */
-    if (!cantweararm(mon) || mon->data->msize == MZ_SMALL)
+    if (!cantweararm(mon) || r_data(mon)->msize == MZ_SMALL)
         m_dowear_type(mon, W_ARMC, creation, FALSE);
     m_dowear_type(mon, W_ARMH, creation, FALSE);
     if (!mw || !bimanual(mw))
@@ -704,7 +704,7 @@ boolean creation;
         m_dowear_type(mon, W_RINGR, creation, FALSE);
 
     m_dowear_type(mon, W_ARMG, creation, FALSE);
-    if (!slithy(mon->data) && mon->data->mlet != S_CENTAUR)
+    if (!slithy(mon->data) && r_data(mon)->mlet != S_CENTAUR)
         m_dowear_type(mon, W_ARMF, creation, FALSE);
     if (!cantweararm(mon))
         m_dowear_type(mon, W_ARM, creation, FALSE);


### PR DESCRIPTION
Noticed a couple small bugs in monster inventory initiation in the process of
trying to figure out why some mplayer tourists weren't generating with
Hawaiian shirts.

- Fix: some racial monster armor rules
- Fix: holdovers from ini_inv in ini_mon_inv
