### PR TITLE
Block monster health regeneration in the Valley

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -769,7 +769,8 @@ int wtcap;
                 && (!Half_physical_damage || !(moves % 2L)))
                 heal = -1;
         } else if (u.mh < u.mhmax) {
-            if (Regeneration || (encumbrance_ok && !(moves % 20L)))
+            if ((!Is_valley(&u.uz) || is_undead(youmonst.data))
+                && (Regeneration || (encumbrance_ok && !(moves % 20L))))
                 heal = 1;
         }
         if (heal && !(Withering && heal > 0)) {

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -209,8 +209,9 @@ mon_regen(mon, digest_meal)
 struct monst *mon;
 boolean digest_meal;
 {
-    if (mon->mhp < mon->mhpmax && (moves % 20 == 0
-                                   || mon_prop(mon, REGENERATION)) && !mon->mwither)
+    if (mon->mhp < mon->mhpmax && !mon->mwither
+        && (!Is_valley(&u.uz) || is_undead(r_data(mon)))
+        && (moves % 20 == 0 || mon_prop(mon, REGENERATION)))
         mon->mhp++;
     if (mon->mspec_used)
         mon->mspec_used--;


### PR DESCRIPTION
Hero health regeneration is blocked in the Valley of the Dead, but the
same didn't apply to monsters (or the hero when polymorphed).  Apply the
same rule to monsters -- except for the undead, which will still recover
hit points in the Valley as before.

Since monsters regenerate HP relatively slowly, the most noticeable
aspect of this change will likely be its effect on the hero's pets
(which normally have a longer lifespan than the average monster).
Polymorphed heros will also now have to contend with the Valley regen
block (unless polymorphed into an undead monster).
