### PR TITLE
Add option to filter by unidentified in item menus

### DIFF
--- a/include/hack.h
+++ b/include/hack.h
@@ -330,6 +330,7 @@ typedef struct sortloot_item Loot;
 #define BUC_CURSED   0x100
 #define BUC_UNCURSED 0x200
 #define BUC_UNKNOWN  0x400
+#define UNIDED_TYPES 0x800
 #define BUC_ALLBKNOWN (BUC_BLESSED | BUC_CURSED | BUC_UNCURSED)
 #define BUCX_TYPES (BUC_ALLBKNOWN | BUC_UNKNOWN)
 #define ALL_TYPES_SELECTED -2

--- a/src/do.c
+++ b/src/do.c
@@ -947,9 +947,8 @@ int retry;
     } else if (flags.menu_style == MENU_FULL) {
         all_categories = FALSE;
         n = query_category("Drop what type of items?", invent,
-                           UNPAID_TYPES | ALL_TYPES | CHOOSE_ALL | BUC_BLESSED
-                               | BUC_CURSED | BUC_UNCURSED | BUC_UNKNOWN,
-                           &pick_list, PICK_ANY);
+                           (UNPAID_TYPES | ALL_TYPES | CHOOSE_ALL | BUCX_TYPES
+                            | UNIDED_TYPES), &pick_list, PICK_ANY);
         if (!n)
             goto drop_done;
         for (i = 0; i < n; i++) {

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -3314,8 +3314,8 @@ int retry;
     } else if (flags.menu_style == MENU_FULL) {
         all_worn_categories = FALSE;
         n = query_category("What type of things do you want to take off?",
-                           invent, (WORN_TYPES | ALL_TYPES
-                                    | UNPAID_TYPES | BUCX_TYPES),
+                           invent, (WORN_TYPES | ALL_TYPES | UNPAID_TYPES
+                                    | BUCX_TYPES | UNIDED_TYPES),
                            &pick_list, PICK_ANY);
         if (!n)
             return 0;


### PR DESCRIPTION
Let users filter by unidentified status using 'I'.  This should work
in standard type-based inventory actions where items affected can be
filtered by type (#loot, 'D'/#droptype, etc) as well as the type-based
inventory listing of 'I'/#inventtype.

The 'I' filter uses not_fully_identified(objnam.c), so an item with a
known type may still be selected by the filter if e.g. its fooproof
status is unknown.

It should work with all the different menustyle options, but I only gave
a relatively cursory check to some of them, so it's definitely possible
that this will introduce some bugs or not work as expected when used
with certain combinations of menustyles and commands.
