### PR TITLE
wintty.c -Wimplicit-function-declaration

### DIFF
--- a/win/tty/wintty.c
+++ b/win/tty/wintty.c
@@ -2827,7 +2827,7 @@ boolean complain;
 #ifdef DEF_PAGER /* this implies that UNIX is defined */
     {
         /* use external pager; this may give security problems */
-        register int fd = open(fname, 0);
+        register int fd = popen(fname, 0);
 
         if (fd < 0) {
             if (complain)


### PR DESCRIPTION
suppresses Gentoo QA compiler warning.

* ../win/tty/wintty.c:2830:27: warning: implicit declaration of function ‘open’; did you mean ‘popen’? [-Wimplicit-function-declaration]