### PR TITLE
Include race in statues of previous players

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1430,6 +1430,7 @@ E struct obj *FDECL(mkcorpstat, (int, struct monst *, struct permonst *, int,
                                  int, unsigned));
 E int FDECL(corpse_revive_type, (struct obj *));
 E struct obj *FDECL(obj_attach_mid, (struct obj *, unsigned));
+E struct obj *FDECL(save_mtraits, (struct obj *, struct monst *));
 E struct monst *FDECL(get_mtraits, (struct obj *, BOOLEAN_P));
 E struct obj *FDECL(mk_tt_object, (int, int, int));
 E struct obj *FDECL(mk_named_object,

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -10,7 +10,6 @@ STATIC_DCL unsigned FDECL(nextoid, (struct obj *, struct obj *));
 STATIC_DCL void FDECL(obj_timer_checks, (struct obj *,
                                          XCHAR_P, XCHAR_P, int));
 STATIC_DCL void FDECL(container_weight, (struct obj *));
-STATIC_DCL struct obj *FDECL(save_mtraits, (struct obj *, struct monst *));
 STATIC_DCL void FDECL(objlist_sanity, (struct obj *, int, const char *));
 STATIC_DCL void FDECL(mon_obj_sanity, (struct monst *, const char *));
 STATIC_DCL const char *FDECL(where_name, (struct obj *));
@@ -1822,7 +1821,7 @@ unsigned mid;
     return obj;
 }
 
-static struct obj *
+struct obj *
 save_mtraits(obj, mtmp)
 struct obj *obj;
 struct monst *mtmp;

--- a/src/mon.c
+++ b/src/mon.c
@@ -5988,8 +5988,15 @@ short raceidx;
     register struct permonst *ptr = &mons[raceidx], *mptr = &mons[mtmp->mnum];
     boolean init = FALSE;
 
-    if (!mtmp || raceidx == NON_PM || mvitals[raceidx].mvflags & G_GONE)
+    if (!mtmp || mvitals[raceidx].mvflags & G_GONE)
         return;
+
+    if (raceidx == NON_PM) {
+        /* apply non-race - clear race data */
+        if (has_erac(mtmp))
+            free_erac(mtmp);
+        return;
+    }
 
     if (!has_erac(mtmp)) {
         newerac(mtmp);


### PR DESCRIPTION
Instead of creating 'a statue of a wizard named K2' make it 'a statue of
a gnomish wizard named K2', using the race information from the top ten
file.

Unfortunately, the current top ten format being used by evilhack is the
deprecated version that predates separation between class and race
selection, so it doesn't include race.  As a result, this patch will not
actually produce an immediately noticeable difference -- but once the
version number increases, it will switch over to start using the modern
record format, and any statues of players from version 0.7.2+ will
include their race.

Normally the changeover to the new top ten record file format would
happen once we reach EvilHack 3.3.0, because that's where it changed in
vanilla NetHack; I updated those criteria in the patch so that EvilHack
will start using the modern format as of 0.7.2.
