### PR TITLE
Mon can drink restore ability to cure cancellation

### DIFF
--- a/src/potion.c
+++ b/src/potion.c
@@ -1705,7 +1705,6 @@ int how;
             if (mon->data == &mons[PM_PESTILENCE])
                 goto do_illness;
             /*FALLTHRU*/
-        case POT_RESTORE_ABILITY:
         case POT_GAIN_ABILITY:
  do_healing:
             angermon = FALSE;
@@ -1716,6 +1715,14 @@ int how;
             }
             if (cureblind)
                 mcureblindness(mon, canseemon(mon));
+            break;
+        case POT_RESTORE_ABILITY:
+            angermon = FALSE;
+            if (mon->mcan) {
+                mon->mcan = 0;
+                if (canseemon(mon))
+                    pline("%s looks revitalized.", Monnam(mon));
+            }
             break;
         case POT_SICKNESS:
             if (mon->data == &mons[PM_PESTILENCE])


### PR DESCRIPTION
Or you can hit a monster with a potion of restore ability to forcibly
uncancel them.

Restore ability no longer acts as a healing potion when wielded and used
to hit a monster.
