### PR TITLE
Fix: guilt from killing summoned minion

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1335,7 +1335,7 @@ E void FDECL(newemin, (struct monst *));
 E void FDECL(free_emin, (struct monst *));
 E int FDECL(monster_census, (BOOLEAN_P));
 E int FDECL(msummon, (struct monst *));
-E void FDECL(summon_minion, (ALIGNTYP_P, BOOLEAN_P));
+E struct monst *FDECL(summon_minion, (ALIGNTYP_P, BOOLEAN_P));
 E int FDECL(demon_talk, (struct monst *));
 E long FDECL(bribe, (struct monst *));
 E int FDECL(dprince, (ALIGNTYP_P));

--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -827,7 +827,8 @@ int spellnum;
 {
     int aligntype, ml = min(mtmp->m_lev, 50);
     static const char *Moloch = "Moloch";
-
+    struct monst *minion = (struct monst *) 0;
+ 
     if (dmg == 0 && !is_undirected_spell(AD_CLRC, spellnum)) {
         impossible("cast directed cleric spell (%d) with dmg=0?", spellnum);
         return;
@@ -835,24 +836,25 @@ int spellnum;
 
     switch (spellnum) {
     case CLC_SUMMON_ELM:
-        if (mtmp->ispriest)
-            aligntype = EPRI(mtmp)->shralign;
-        else
-            aligntype = sgn(mon_aligntyp(mtmp));
 
-        if (aligntype == A_NONE) {
-            pline("A vassal of %s appears!", Moloch);
-            summon_minion(aligntype, TRUE);
-        } else {
-            if (mtmp->data == &mons[PM_KATHRYN_THE_ICE_QUEEN]) {
-                coord bypos;
-                if (!enexto(&bypos, mtmp->mx, mtmp->my, mtmp->data))
-                    break;
+        if (mtmp->data == &mons[PM_KATHRYN_THE_ICE_QUEEN]) {
+            coord bypos;
+            if (!enexto(&bypos, mtmp->mx, mtmp->my, mtmp->data))
+                break;
+            minion = makemon(&mons[PM_SNOW_GOLEM], bypos.x, bypos.y,
+                             MM_ANGRY);
+            if (minion && canspotmon(minion))
                 pline("A minion of %s appears!", mon_nam(mtmp));
-                makemon(&mons[PM_SNOW_GOLEM], bypos.x, bypos.y, MM_ANGRY);
-            } else {
-	        pline("A servant of %s appears!", aligns[1 - aligntype].noun);
-	        summon_minion(aligntype, TRUE);
+        } else {
+            aligntype = mon_aligntyp(mtmp);
+            minion = summon_minion(aligntype, FALSE);
+            if (minion) {
+                boolean vassal = (aligntype == A_NONE);
+                set_malign(minion);
+                if (canspotmon(minion))
+                    pline("A %s of %s appears!",
+                          vassal ? "vassal" : "servant",
+                          vassal ? Moloch : aligns[1 - aligntype].noun);
             }
         }
         dmg = 0;
@@ -2194,6 +2196,7 @@ int spellnum;
     int aligntype;
     static const char *Moloch = "Moloch";
     boolean yours = (mattk == &youmonst);
+    struct monst *minion = (struct monst *) 0;
 
     if (dmg == 0 && !is_undirected_spell(AD_CLRC, spellnum)) {
        	impossible("cast directed cleric spell (%d) with dmg=0?", spellnum);
@@ -2212,18 +2215,12 @@ int spellnum;
             return;
         }
 
-        if (mtmp->ispriest)
-            aligntype = EPRI(mtmp)->shralign;
-        else
-            aligntype = sgn(mon_aligntyp(mtmp));
-
-        if (aligntype == A_NONE) {
-            pline("A vassal of %s appears!", Moloch);
-            summon_minion(aligntype, TRUE);
-        } else {
-            pline("A servant of %s appears!", aligns[1 - aligntype].noun);
-            summon_minion(aligntype, TRUE);
-        }
+        aligntype = yours ? u.ualign.type : mon_aligntyp(mattk);
+        minion = summon_minion(aligntype, FALSE);
+        if (minion && canspotmon(minion))
+            pline("A %s of %s appears!",
+                  aligntype == A_NONE ? "vassal" : "servant",
+                  aligntype == A_NONE ? Moloch : aligns[1 - aligntype].noun);
         dmg = 0;
         break;
     case CLC_GEYSER:
@@ -2365,7 +2362,7 @@ int spellnum;
                 mtmp->mblinded = 127;
             }
             dmg = 0;
-        } else
+        } else if (!yours)
             impossible("no reason for monster to cast blindness spell?");
         break;
     case CLC_PARALYZE:

--- a/src/minion.c
+++ b/src/minion.c
@@ -166,7 +166,7 @@ struct monst *mon;
     return result;
 }
 
-void
+struct monst *
 summon_minion(alignment, talk)
 aligntyp alignment;
 boolean talk;

--- a/src/pray.c
+++ b/src/pray.c
@@ -667,9 +667,9 @@ aligntyp resp_god;
         if (Is_astralevel(&u.uz) || Is_sanctum(&u.uz)) {
             /* one more try for high altars */
             verbalize("Thou cannot escape my wrath, mortal!");
-            summon_minion(resp_god, FALSE);
-            summon_minion(resp_god, FALSE);
-            summon_minion(resp_god, FALSE);
+            (void) summon_minion(resp_god, FALSE);
+            (void) summon_minion(resp_god, FALSE);
+            (void) summon_minion(resp_god, FALSE);
             verbalize("Destroy %s, my servants!", uhim());
         }
     }
@@ -751,7 +751,7 @@ aligntyp resp_god;
         /* [why isn't this using verbalize()?] */
         pline("\"Then die, %s!\"",
               (youmonst.data->mlet == S_HUMAN) ? "mortal" : "creature");
-        summon_minion(resp_god, FALSE);
+        (void) summon_minion(resp_god, FALSE);
         break;
 
     default:
@@ -2040,7 +2040,7 @@ dosacrifice()
                     if (u.ualign.record > 0 && rnd(u.ualign.record)
                         > (3 * ALIGNLIM) / (temple_occupied(u.urooms)
                         ? 12 : u.ulevel)) {
-			    summon_minion(altaralign, TRUE);
+			    (void) summon_minion(altaralign, TRUE);
 		    }
                     /* anger priest; test handles bones files */
                     if ((pri = findpriest(temple_occupied(u.urooms)))
@@ -2053,7 +2053,7 @@ dosacrifice()
                     exercise(A_WIS, FALSE);
                     if (rnl(u.ulevel) > 6 && u.ualign.record > 0
                         && rnd(u.ualign.record) > (7 * ALIGNLIM) / 8)
-                        summon_minion(altaralign, TRUE);
+                        (void) summon_minion(altaralign, TRUE);
                 }
                 return 1;
             }


### PR DESCRIPTION
Set maligntyp for minion summoned by an enemy cleric so that you don't
abuse your alignment.  Also do some refactoring and fix some bugs with
player casting of the spell.
