### PR TITLE
Freezing water/lava with WDSM

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1517,6 +1517,7 @@ E boolean FDECL(mpickstuff, (struct monst *, const char *));
 E int FDECL(curr_mon_load, (struct monst *));
 E int FDECL(max_mon_load, (struct monst *));
 E int FDECL(can_carry, (struct monst *, struct obj *));
+E boolean FDECL(has_cold_feet, (struct monst *));
 E int FDECL(mfndpos, (struct monst *, coord *, long *, long));
 E long FDECL(mm_aggression, (struct monst *, struct monst *));
 E boolean FDECL(monnear, (struct monst *, int, int));

--- a/include/extern.h
+++ b/include/extern.h
@@ -1649,6 +1649,7 @@ E boolean FDECL(accessible, (int, int));
 E void FDECL(set_apparxy, (struct monst *));
 E boolean FDECL(can_ooze, (struct monst *));
 E boolean FDECL(can_fog, (struct monst *));
+E int FDECL(maybe_freeze_underfoot, (struct monst *));
 E boolean FDECL(should_displace,
                 (struct monst *, coord *, long *, int, XCHAR_P, XCHAR_P));
 E boolean FDECL(undesirable_disp, (struct monst *, XCHAR_P, XCHAR_P));

--- a/src/hack.c
+++ b/src/hack.c
@@ -2203,9 +2203,7 @@ domove_core()
 
     /* Special effects of WDSM; don't spam the player unless they've stepped onto
      * water from something that wasn't water/ice already */
-    if (is_damp_terrain(u.ux, u.uy) && uarm
-        && (uarm->otyp == WHITE_DRAGON_SCALE_MAIL
-            || uarm->otyp == WHITE_DRAGON_SCALES)) {
+    if (is_damp_terrain(u.ux, u.uy) && has_cold_feet(&youmonst)) {
         struct rm *lev = &levl[u.ux][u.uy];
         if (lev->typ == DRAWBRIDGE_UP) {
             lev->drawbridgemask &= ~DB_UNDER;

--- a/src/hack.c
+++ b/src/hack.c
@@ -2201,29 +2201,8 @@ domove_core()
     if (Punished) /* put back ball and chain */
         move_bc(0, bc_control, ballx, bally, chainx, chainy);
 
-    /* Special effects of WDSM; don't spam the player unless they've stepped onto
-     * water from something that wasn't water/ice already */
-    if (is_damp_terrain(u.ux, u.uy) && has_cold_feet(&youmonst)) {
-        struct rm *lev = &levl[u.ux][u.uy];
-        if (lev->typ == DRAWBRIDGE_UP) {
-            lev->drawbridgemask &= ~DB_UNDER;
-            lev->drawbridgemask |= DB_ICE;
-        } else {
-            lev->icedpool = (lev->typ == POOL) ? ICED_POOL
-                              : (lev->typ == PUDDLE) ? ICED_PUDDLE
-                                 : (lev->typ == SEWAGE) ? ICED_SEWAGE
-                                                        : ICED_MOAT;
-            lev->typ = ICE;
-        }
-        if (!(lev->icedpool == ICED_PUDDLE
-              || lev->icedpool == ICED_SEWAGE))
-            bury_objs(u.ux, u.uy);
-        if (!is_pool(u.ux0, u.uy0) && !is_ice(u.ux0, u.uy0))
-            pline("The %s crackles and freezes under your feet.",
-                  hliquid(is_sewage(u.ux, u.uy) ? "sewage" : "water"));
-         start_melt_ice_timeout(u.ux, u.uy, 0L);
-         obj_ice_effects(u.ux, u.uy, TRUE);
-    }
+    /* Special effects of WDSM */
+    (void) maybe_freeze_underfoot(&youmonst);
 
     if (u.umoved)
         spoteffects(TRUE);
@@ -2398,6 +2377,8 @@ boolean newspot;             /* true if called by spoteffects */
 
     /* check for entering water or lava */
     if (!u.ustuck && !Levitation && !Flying) {
+        if (maybe_freeze_underfoot(&youmonst))
+            return FALSE;
         if (is_pool_or_lava(u.ux, u.uy)) {
             if (u.usteed
                 && (is_flyer(u.usteed->data) || is_floater(u.usteed->data)

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -1790,8 +1790,9 @@ register struct attack *mattk;
                     u.ustuck = mtmp;
                 }
             } else if (u.ustuck == mtmp) {
+                boolean freeze = has_cold_feet(&youmonst);
                 if (is_pool(mtmp->mx, mtmp->my) && !Swimming && !Amphibious
-                    && mtmp->data != &mons[PM_MIND_FLAYER_LARVA]) {
+                    && !freeze && mtmp->data != &mons[PM_MIND_FLAYER_LARVA]) {
                     boolean moat = (levl[mtmp->mx][mtmp->my].typ != POOL)
                                    && (levl[mtmp->mx][mtmp->my].typ != WATER)
                                    && !Is_medusa_level(&u.uz)
@@ -1803,7 +1804,7 @@ register struct attack *mattk;
                             moat ? "moat" : "pool of water",
                             an(mtmp->data->mname));
                     done(DROWNING);
-                } else if (is_lava(mtmp->mx, mtmp->my)) {
+                } else if (is_lava(mtmp->mx, mtmp->my) && !freeze) {
                     pline("%s pulls you into the lava...", Monnam(mtmp));
                     killer.format = NO_KILLER_PREFIX;
                     Sprintf(killer.name, "incinerated in molten lava by %s",

--- a/src/mon.c
+++ b/src/mon.c
@@ -2041,6 +2041,33 @@ struct obj *otmp;
     return iquan;
 }
 
+boolean
+has_cold_feet(mtmp)
+struct monst *mtmp;
+{
+#define freezing_armor(typ) \
+    ((typ) == WHITE_DRAGON_SCALES || (typ) == WHITE_DRAGON_SCALE_MAIL)
+
+    boolean is_you = (mtmp == &youmonst);
+    if (is_you) {
+        if (uarm && freezing_armor(uarm->otyp))
+            return TRUE;
+    } else {
+        struct obj *otmp;
+        for (otmp = mtmp->minvent; otmp; otmp = otmp->nobj) {
+            if ((otmp->owornmask & W_ARMOR) && freezing_armor(otmp->otyp)) {
+                return TRUE;
+            }
+        }
+    }
+
+    if (freeze_step(mtmp->data))
+        return TRUE;
+
+    return FALSE;
+#undef freezing_armor
+}
+
 /* return number of acceptable neighbour positions */
 int
 mfndpos(mon, poss, info, flag)
@@ -2076,12 +2103,12 @@ long flag;
     wantice = (mdat == &mons[PM_FROST_SALAMANDER]);
     poolok = ((!Is_waterlevel(&u.uz)
                && (is_flyer(mdat) || is_floater(mdat) || is_clinger(mdat)))
-              || ((is_swimmer(mdat) || freeze_step(mdat)) && !wantpool)
+              || ((is_swimmer(mdat) || has_cold_feet(mon)) && !wantpool)
               || can_wwalk(mon));
     /* note: floating eye is the only is_floater() so this could be
        simplified, but then adding another floater would be error prone */
     lavaok = (is_flyer(mdat) || is_floater(mdat) || is_clinger(mdat)
-              || (likes_lava(mdat) && !wantlava));
+              || ((has_cold_feet(mon) || likes_lava(mdat)) && !wantlava));
     if (mdat == &mons[PM_FLOATING_EYE]) /* prefers to avoid heat */
         lavaok = FALSE;
     thrudoor = ((flag & (ALLOW_WALL | BUSTDOOR)) != 0L);

--- a/src/mon.c
+++ b/src/mon.c
@@ -2049,6 +2049,10 @@ struct monst *mtmp;
     ((typ) == WHITE_DRAGON_SCALES || (typ) == WHITE_DRAGON_SCALE_MAIL)
 
     boolean is_you = (mtmp == &youmonst);
+
+    if (Is_waterlevel(&u.uz))
+        return FALSE;
+
     if (is_you) {
         if (uarm && freezing_armor(uarm->otyp))
             return TRUE;

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -950,15 +950,12 @@ level_tele()
          * stay put. we let negative values requests fall into the "heaven" handling.
          * while Cerberus is alive, levelporting past the Valley is impossible,
          * but once he is defeated, the ability opens back up */
-        if (Is_knox(&u.uz) && newlev > 0 && !force_dest) {
+        if (newlev > 0 && !force_dest
+            && ((Is_valley(&u.uz) && !u.uevent.ucerberus
+                 && (!wizard || yn("Cerberus is alive. Override?") != 'y'))
+                || Is_knox(&u.uz))) {
             You1(shudder_for_moment);
             return;
-        }
-        if (!u.uevent.ucerberus) {
-            if (Is_valley(&u.uz) && newlev > 0 && !force_dest) {
-                You1(shudder_for_moment);
-                return;
-            }
         }
         /* if in Quest, the player sees "Home 1", etc., on the status
          * line, instead of the logical depth of the level.  controlled

--- a/src/trap.c
+++ b/src/trap.c
@@ -3426,9 +3426,7 @@ long hmask, emask; /* might cancel timeout */
         if (is_pool(u.ux, u.uy) && !Wwalking && !Swimming && !u.uinwater)
             no_msg = drown();
 
-        if (is_damp_terrain(u.ux, u.uy) && uarm
-            && (uarm->otyp == WHITE_DRAGON_SCALE_MAIL
-                || uarm->otyp == WHITE_DRAGON_SCALES)) {
+        if (is_damp_terrain(u.ux, u.uy) && has_cold_feet(&youmonst)) {
             struct rm *lev = &levl[u.ux][u.uy];
             if (lev->typ == DRAWBRIDGE_UP) {
                 lev->drawbridgemask &= ~DB_UNDER;
@@ -3443,7 +3441,7 @@ long hmask, emask; /* might cancel timeout */
             if (!(lev->icedpool == ICED_PUDDLE
                   || lev->icedpool == ICED_SEWAGE))
                 bury_objs(u.ux, u.uy);
-            pline("The %s crackles and freezes under your feet.",
+            pline_The("%s crackles and freezes under your feet.",
                   hliquid(is_sewage(u.ux, u.uy) ? "sewage" : "water"));
             start_melt_ice_timeout(u.ux, u.uy, 0L);
             obj_ice_effects(u.ux, u.uy, TRUE);
@@ -6191,6 +6189,20 @@ lava_effects()
     int dmg = resist_reduce(d(6, 6), FIRE_RES); /* only applicable for water walking */
     boolean usurvive, boil_away;
 
+    if (has_cold_feet(&youmonst)) {
+        struct rm *lev = &levl[u.ux][u.uy];
+        if (lev->typ == DRAWBRIDGE_UP) {
+            lev->drawbridgemask &= ~DB_UNDER;
+            lev->drawbridgemask |= DB_ICE;
+        } else {
+            lev->typ = ROOM;
+        }
+        if (!rn2(4))
+            pline_The("lava cools and solidifies under your feet.");
+        feel_newsym(u.ux, u.uy);
+        return TRUE;
+    }
+
     feel_newsym(u.ux, u.uy); /* in case Blind, map the lava here */
     burn_away_slime();
 
@@ -6235,20 +6247,14 @@ lava_effects()
 
     if (how_resistant(FIRE_RES) < 100) {
         if (Wwalking) {
-            if (uarm && (uarm->otyp == WHITE_DRAGON_SCALE_MAIL
-                         || uarm->otyp == WHITE_DRAGON_SCALES)) {
-                levl[u.ux][u.uy].typ = ROOM;
-                if (!rn2(4))
-                    pline_The("lava cools and solidifies under your feet.");
-                return TRUE;
-            }
             pline_The("%s here burns you!", hliquid("lava"));
             if (usurvive) {
                 losehp(dmg, lava_killer, KILLED_BY); /* lava damage */
                 goto burn_stuff;
             }
-        } else
+        } else {
             You("fall into the %s!", hliquid("lava"));
+        }
 
         usurvive = Lifesaved || discover;
         if (wizard)
@@ -6315,14 +6321,6 @@ lava_effects()
         if (u.uhp > 1)
             losehp(!boil_away ? 1 : (u.uhp / 2), lava_killer,
                    KILLED_BY); /* lava damage */
-    } else {
-        if (uarm && (uarm->otyp == WHITE_DRAGON_SCALE_MAIL
-                     || uarm->otyp == WHITE_DRAGON_SCALES)) {
-            levl[u.ux][u.uy].typ = ROOM;
-            if (!rn2(4))
-                pline_The("lava cools and solidifies under your feet.");
-            return TRUE;
-        }
     }
 
 burn_stuff:


### PR DESCRIPTION
Make lava/water freezing power a little more consistent, and fix a
couple bugs associated with it.

Some of the issues: wearing WDSM and walking on lava under a drawbridge
would permanently break it (see 159b351, which missed the lava case);
monsters wouldn't get freezing power from wearing WDSM; contrariwise,
the hero wouldn't get freezing power from a freezing polyform; freezing
wouldn't work when a monster tries to drown the hero in water/lava;
freezing worked strangely on lava (e.g. your boots would burn up, but
other inventory items wouldn't, unless you were 100% fire-resistant and
didn't have water walking, in which case you would sink into the lava).

I wouldn't be surprised if this introduced its own new and exciting bugs.

Also includes an unrelated commit allowing the player to override the Cerberus levelport block in wizard mode.