### PR TITLE
Fix: Show proper artifact name when it resists being held second.

### DIFF
--- a/src/wield.c
+++ b/src/wield.c
@@ -706,7 +706,7 @@ can_twoweapon()
              && ((is_lawful_artifact(uswapwep) && is_chaotic_artifact(uwep))
                  || (is_chaotic_artifact(uswapwep) && is_lawful_artifact(uwep))))
         pline("%s being held second to an opposite aligned weapon!",
-              Yobjnam2(uwep, "resist"));
+              Yobjnam2(uswapwep, "resist"));
     else if (uswapwep->otyp == CORPSE && cant_wield_corpse(uswapwep)) {
         /* [Note: NOT_WEAPON() check prevents ever getting here...] */
         ; /* must be life-saved to reach here; return FALSE */


### PR DESCRIPTION
Noticed when attempting to dual-wield Sword of Kas with Tsurugi of Muramasa like a gormless fool. This make the message use the secondary "wielded in other hand" weapon as the subject of the resist message.

a) Tsurugi of Muramasa (weapon in hand)
b) Sword of Kas (alternate weapon; not wielded)

Illegal desired outcome from dual-wielding: "Sword of Kas (wielded in other hand)".

Old behavior: "Your Tsurugi of Muramasa resists being held second to an opposite aligned weapon!"

New behavior: "Your Sword of Kas resists being held second to an opposite aligned weapon!"
