### PR TITLE
Clingy mimics

### DIFF
--- a/doc/evilhack-changelog.md
+++ b/doc/evilhack-changelog.md
@@ -2140,7 +2140,6 @@ The following changes to date are:
 - Fix: tweak goodpos() fix when a monster engulfs the player
 - Fix: monster casting 'summon insects' spell at another monster would
   target the player instead
-- Fix: large/giant mimics spawning or travelling where they shouldn't
 - Fix: sparkle animation patch
 - Monster spell 'reflection' can timeout
 - Knights get no caitiff penalty against undead

--- a/doc/evilhack-changelog.md
+++ b/doc/evilhack-changelog.md
@@ -2167,5 +2167,4 @@ The following changes to date are:
   cancellation
 - Adjust livelogging of altar sacrifice gifts
 - Fix: prevent monster hurtling outside map
-- Fix: wumpus movement over water/lava and open air in Vlad's cavern
 

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -96,7 +96,7 @@
 #define is_floater(ptr) ((ptr)->mlet == S_EYE || (ptr)->mlet == S_LIGHT)
 /* clinger: piercers, mimics, wumpus -- generally don't fall down holes */
 #define is_clinger(ptr) (((ptr)->mflags1 & M1_CLING) != 0L)
-#define grounded(ptr) (!is_flyer(ptr) && !is_floater(ptr) && !ceiling_hider(ptr))
+#define grounded(ptr) (!is_flyer(ptr) && !is_floater(ptr) && !is_clinger(ptr))
 #define is_swimmer(ptr) (((ptr)->mflags1 & M1_SWIM) != 0L)
 #define breathless(ptr) (((ptr)->mflags1 & M1_BREATHLESS) != 0L)
 #define amphibious(ptr) \

--- a/include/mondata.h
+++ b/include/mondata.h
@@ -120,12 +120,10 @@
 /* piercers cling to the ceiling; lurkers above are hiders but they fly
    so aren't classified as clingers; unfortunately mimics are classified
    as both hiders and clingers but have nothing to do with ceilings;
-   wumpuses cling but aren't hiders, but we include them regardless */
+   wumpuses (not wumpi :-) cling but aren't hiders */
 #define ceiling_hider(ptr) \
-    ((is_hider(ptr)                                   \
-      && ((is_clinger(ptr) && (ptr)->mlet != S_MIMIC) \
-          || is_flyer(ptr)))                          \
-     || (ptr) == &mons[PM_WUMPUS])
+    (is_hider(ptr) && ((is_clinger(ptr) && (ptr)->mlet != S_MIMIC) \
+                       || is_flyer(ptr))) /* lurker above */
 #define haseyes(ptr) (((ptr)->mflags1 & M1_NOEYES) == 0L)
 /* used to decide whether plural applies so no need for 'more than 2' */
 #define eyecount(ptr) \

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -3474,7 +3474,7 @@ int msgflag;          /* for variant message phrasing */
 
             if (o)
                 Sprintf(bp, " underneath %s", ansimpleoname(o));
-        } else if (ceiling_hider(youmonst.data) || Flying) {
+        } else if (is_clinger(youmonst.data) || Flying) {
             /* Flying: 'lurker above' hides on ceiling but doesn't cling */
             Sprintf(bp, " on the %s", ceiling(u.ux, u.uy));
         } else {

--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -359,7 +359,7 @@ Boots_off(VOID_ARGS)
     case WATER_WALKING_BOOTS:
         /* check for lava since fireproofed boots make it viable */
         if ((is_pool(u.ux, u.uy) || is_lava(u.ux, u.uy))
-            && !Levitation && !Flying && !ceiling_hider(youmonst.data)
+            && !Levitation && !Flying && !is_clinger(youmonst.data)
             && !context.takeoff.cancelled_don
             /* avoid recursive call to lava_effects() */
             && !iflags.in_lava_effects) {

--- a/src/eat.c
+++ b/src/eat.c
@@ -3381,7 +3381,7 @@ int corpsecheck; /* 0, no check, 1, corpses, 2, tinnable corpses */
     if (iflags.menu_requested /* command was preceded by 'm' prefix */
         || !can_reach_floor(TRUE) || (feeding && u.usteed)
         || (is_pool_or_lava(u.ux, u.uy)
-            && (Wwalking || ceiling_hider(youmonst.data)
+            && (Wwalking || is_clinger(youmonst.data)
                 || (Flying && !Breathless))))
         goto skipfloor;
 

--- a/src/hack.c
+++ b/src/hack.c
@@ -1018,7 +1018,7 @@ int mode;
         struct trap *t = t_at(x, y);
 
         if ((t && t->tseen)
-            || (!Levitation && !Flying && !ceiling_hider(youmonst.data)
+            || (!Levitation && !Flying && !is_clinger(youmonst.data)
                 && is_pool_or_lava(x, y) && levl[x][y].seenv))
             return (mode == TEST_TRAP);
     }
@@ -1582,7 +1582,7 @@ domove_core()
                 skates = find_skates();
             if ((uarmf && uarmf->otyp == skates) || resists_cold(&youmonst)
                 || Flying || is_floater(youmonst.data)
-                || ceiling_hider(youmonst.data) || is_whirly(youmonst.data)
+                || is_clinger(youmonst.data) || is_whirly(youmonst.data)
 		|| (uarm && (uarm->otyp == WHITE_DRAGON_SCALE_MAIL
 	                     || uarm->otyp == WHITE_DRAGON_SCALES))) {
                 on_ice = FALSE;
@@ -1600,7 +1600,7 @@ domove_core()
         if (walk_sewage) {
             if (Flying || is_floater(youmonst.data)
                 || is_swimmer(youmonst.data)
-                || ceiling_hider(youmonst.data) || is_whirly(youmonst.data)
+                || is_clinger(youmonst.data) || is_whirly(youmonst.data)
                 || (uarm && (uarm->otyp == WHITE_DRAGON_SCALE_MAIL
                              || uarm->otyp == WHITE_DRAGON_SCALES))) {
                 walk_sewage = FALSE;
@@ -1671,7 +1671,7 @@ domove_core()
             return;
         }
         if (((trap = t_at(x, y)) && trap->tseen)
-            || (Blind && !Levitation && !Flying && !ceiling_hider(youmonst.data)
+            || (Blind && !Levitation && !Flying && !is_clinger(youmonst.data)
                 && is_pool_or_lava(x, y) && levl[x][y].seenv)) {
             if (context.run >= 2) {
                 if (iflags.mention_walls) {
@@ -2382,7 +2382,7 @@ boolean newspot;             /* true if called by spoteffects */
         if (is_pool_or_lava(u.ux, u.uy)) {
             if (u.usteed
                 && (is_flyer(u.usteed->data) || is_floater(u.usteed->data)
-                    || ceiling_hider(u.usteed->data))) {
+                    || is_clinger(u.usteed->data))) {
                 /* floating or clinging steed keeps hero safe (is_flyer() test
                    is redundant; it can't be true since Flying yielded false) */
                 return FALSE;
@@ -2619,8 +2619,8 @@ boolean pick;
         mnexto(mtmp); /* have to move the monster */
     }
     if (IS_AIR(levl[u.ux][u.uy].typ) && In_V_tower(&u.uz)
-        && !Levitation && !Flying && !ceiling_hider(youmonst.data)
-        && !(u.usteed && ceiling_hider(u.usteed->data))) {
+        && !Levitation && !Flying && !is_clinger(youmonst.data)
+        && !(u.usteed && is_clinger(u.usteed->data))) {
         pline("Unfortunately, you don't know how to fly.");
         You("plummet several thousand feet to your death.");
         Sprintf(killer.name,
@@ -2986,7 +2986,7 @@ pickup_checks()
         }
     }
     if (is_pool(u.ux, u.uy)) {
-        if (Wwalking || is_floater(youmonst.data) || ceiling_hider(youmonst.data)
+        if (Wwalking || is_floater(youmonst.data) || is_clinger(youmonst.data)
             || (Flying && !Breathless)) {
             You("cannot dive into the %s to pick things up.",
                 hliquid("water"));
@@ -2997,7 +2997,7 @@ pickup_checks()
         }
     }
     if (is_lava(u.ux, u.uy)) {
-        if (Wwalking || is_floater(youmonst.data) || ceiling_hider(youmonst.data)
+        if (Wwalking || is_floater(youmonst.data) || is_clinger(youmonst.data)
             || (Flying && !Breathless)) {
             You_cant("reach the bottom to pick things up.");
             return 0;
@@ -3169,7 +3169,7 @@ lookaround()
                 /* water and lava only stop you if directly in front, and stop
                  * you even if you are running
                  */
-                if (!Levitation && !Flying && !ceiling_hider(youmonst.data)
+                if (!Levitation && !Flying && !is_clinger(youmonst.data)
                     && x == u.ux + u.dx && y == u.uy + u.dy) {
                     /* No Wwalking check; otherwise they'd be able
                      * to test boots by trying to SHIFT-direction
@@ -3182,8 +3182,8 @@ lookaround()
                 }
                 continue;
             } else if (IS_AIR(levl[x][y].typ) && In_V_tower(&u.uz)) {
-                if (!Levitation && !Flying && !ceiling_hider(youmonst.data)
-                    && !(u.usteed && ceiling_hider(u.usteed->data))
+                if (!Levitation && !Flying && !is_clinger(youmonst.data)
+                    && !(u.usteed && is_clinger(u.usteed->data))
                     && x == u.ux + u.dx && y == u.uy + u.dy) {
                     goto stop;
                 }

--- a/src/makemon.c
+++ b/src/makemon.c
@@ -3746,6 +3746,12 @@ register struct monst *mtmp;
             appear = Is_rogue_level(&u.uz) ? S_hwall : S_hcdoor;
         else
             appear = Is_rogue_level(&u.uz) ? S_vwall : S_vcdoor;
+    } else if ((IS_AIR(typ) && In_V_tower(&u.uz))
+               || is_pool_or_lava(mx, my)) {
+        /* mimics cling to the ceiling over inaccessible terrain, but there's
+         * no appropriate disguise that hangs from the ceiling */
+        ap_type = M_AP_NOTHING;
+        appear = 0;
     } else if (level.flags.is_maze_lev && !In_sokoban(&u.uz) && rn2(2)) {
         ap_type = M_AP_OBJECT;
         appear = STATUE;

--- a/src/mon.c
+++ b/src/mon.c
@@ -841,7 +841,7 @@ register struct monst *mtmp;
          * protect their stuff. Fire resistant monsters can only protect
          * themselves  --ALI
          */
-        if (!ceiling_hider(mtmp->data) && !likes_lava(mtmp->data)) {
+        if (!is_clinger(mtmp->data) && !likes_lava(mtmp->data)) {
             /* not fair...?  hero doesn't automatically teleport away
                from lava, just from water */
             if (can_teleport(mtmp->data) && !tele_restrict(mtmp)) {
@@ -914,7 +914,7 @@ register struct monst *mtmp;
          * water damage to dead monsters' inventory, but survivors need to
          * be handled here.  Swimmers are able to protect their stuff...
          */
-        if (!ceiling_hider(mtmp->data) && !is_swimmer(mtmp->data)
+        if (!is_clinger(mtmp->data) && !is_swimmer(mtmp->data)
             && !amphibious(mtmp->data) && !can_wwalk(mtmp)) {
             /* like hero with teleport intrinsic or spell, teleport away
                if possible */
@@ -2140,12 +2140,12 @@ long flag;
     wantsewage = (mdat == &mons[PM_GIANT_LEECH]);
     wantice = (mdat == &mons[PM_FROST_SALAMANDER]);
     poolok = ((!Is_waterlevel(&u.uz)
-               && (is_flyer(mdat) || is_floater(mdat) || ceiling_hider(mdat)))
+               && (is_flyer(mdat) || is_floater(mdat) || is_clinger(mdat)))
               || ((is_swimmer(mdat) || has_cold_feet(mon)) && !wantpool)
               || can_wwalk(mon));
     /* note: floating eye is the only is_floater() so this could be
        simplified, but then adding another floater would be error prone */
-    lavaok = (is_flyer(mdat) || is_floater(mdat) || ceiling_hider(mdat)
+    lavaok = (is_flyer(mdat) || is_floater(mdat) || is_clinger(mdat)
               || ((has_cold_feet(mon) || likes_lava(mdat)) && !wantlava));
     if (mdat == &mons[PM_FLOATING_EYE]) /* prefers to avoid heat */
         lavaok = FALSE;
@@ -2228,7 +2228,7 @@ long flag;
             /* avoid open air if gravity is in effect */
             if (IS_AIR(ntyp) && In_V_tower(&u.uz)
                 && !(is_flyer(mdat) || is_floater(mdat)
-                     || ceiling_hider(mdat)))
+                     || is_clinger(mdat)))
                 continue;
             if ((is_pool(nx, ny) == wantpool || poolok)
                 && (is_lava(nx, ny) == wantlava || lavaok)
@@ -2342,7 +2342,7 @@ long flag;
                         && ttmp->ttyp != VIBRATING_SQUARE
                         && ((!is_pit(ttmp->ttyp) && !is_hole(ttmp->ttyp))
                             || (!is_flyer(mdat) && !is_floater(mdat)
-                                && !ceiling_hider(mdat)) || Sokoban)
+                                && !is_clinger(mdat)) || Sokoban)
                         && (ttmp->ttyp != SLP_GAS_TRAP
                             || !(resists_sleep(mon) || defended(mon, AD_SLEE)))
                         && (ttmp->ttyp != BEAR_TRAP

--- a/src/mon.c
+++ b/src/mon.c
@@ -760,7 +760,7 @@ register struct monst *mtmp;
                  && !(is_flyer(mtmp->data) || is_floater(mtmp->data)));
     invladcavern = (IS_AIR(levl[mtmp->mx][mtmp->my].typ) && In_V_tower(&u.uz)
                     && !(is_flyer(mtmp->data) || is_floater(mtmp->data)
-                         || ceiling_hider(mtmp->data)
+                         || is_clinger(mtmp->data)
                          || ((mtmp == u.usteed) && Flying)));
 
     /* Flying and levitation keeps our steed out of the liquid

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -553,7 +553,7 @@ register struct monst *mtmp;
     /* some monsters are slowed down if wading through sewage */
     if (mwalk_sewage) {
         if (is_flyer(mdat) || is_floater(mdat)
-            || ceiling_hider(mdat) || is_swimmer(mdat)
+            || is_clinger(mdat) || is_swimmer(mdat)
             || passes_walls(mdat)) {
             mwalk_sewage = FALSE;
         } else {
@@ -566,7 +566,7 @@ register struct monst *mtmp;
     /* being in midair where gravity is still in effect can be lethal */
     if (IS_AIR(levl[mtmp->mx][mtmp->my].typ) && In_V_tower(&u.uz)
         && !(is_flyer(mdat) || is_floater(mdat)
-             || ceiling_hider(mdat) || ((mtmp == u.usteed) && Flying))) {
+             || is_clinger(mdat) || ((mtmp == u.usteed) && Flying))) {
         if (canseemon(mtmp))
             pline("%s plummets several thousand feet to %s death.",
                   Monnam(mtmp), mhis(mtmp));
@@ -1387,7 +1387,7 @@ register int after;
                        is in effect */
                     if (IS_AIR(levl[xx][yy].typ) && In_V_tower(&u.uz)
                         && !(is_flyer(ptr) || is_floater(ptr)
-                             || ceiling_hider(ptr)))
+                             || is_clinger(ptr)))
                         continue;
 
                     /* ignore sokoban prizes */

--- a/src/music.c
+++ b/src/music.c
@@ -387,7 +387,7 @@ int force;
                 /* We have to check whether monsters or player
                    falls in a chasm... */
                 if (mtmp) {
-                    if (!is_flyer(mtmp->data) && !ceiling_hider(mtmp->data)) {
+                    if (!is_flyer(mtmp->data) && !is_clinger(mtmp->data)) {
                         boolean m_already_trapped = mtmp->mtrapped;
 
                         mtmp->mtrapped = 1;
@@ -429,7 +429,7 @@ int force;
                         Your("chain breaks!");
                         reset_utrap(TRUE);
                     }
-                    if (Levitation || Flying || ceiling_hider(youmonst.data)) {
+                    if (Levitation || Flying || is_clinger(youmonst.data)) {
                         if (!tu_pit) { /* no pit here previously */
                             pline("A chasm opens up under you!");
                             You("don't fall in!");

--- a/src/pager.c
+++ b/src/pager.c
@@ -959,7 +959,7 @@ struct permonst * pm;
         APPENDC(is_flyer(pm), "fly");
     APPENDC(passes_walls(pm), "phase through walls");
     APPENDC(can_teleport(pm), "teleport");
-    APPENDC(ceiling_hider(pm), "cling to the ceiling");
+    APPENDC(is_clinger(pm), "cling to the ceiling");
     APPENDC(is_jumper(pm), "jump");
     APPENDC(webmaker(pm), "spin webs");
     APPENDC(needspick(pm), "mine");

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1544,7 +1544,7 @@ int
 dohide()
 {
     boolean ismimic = youmonst.data->mlet == S_MIMIC,
-            on_ceiling = ceiling_hider(youmonst.data) || Flying;
+            on_ceiling = is_clinger(youmonst.data) || Flying;
 
     /* can't hide while being held (or holding) or while trapped
        (except for floor hiders [trapper or mimic] in pits) */

--- a/src/steed.c
+++ b/src/steed.c
@@ -958,7 +958,7 @@ int reason; /* Player was thrown off etc. */
             struct permonst *mdat = mtmp->data;
 
             /* The steed may drop into water/lava */
-            if (!is_flyer(mdat) && !is_floater(mdat) && !ceiling_hider(mdat)) {
+            if (!is_flyer(mdat) && !is_floater(mdat) && !is_clinger(mdat)) {
                 if (is_pool(u.ux, u.uy)) {
                     if (!Underwater)
                         pline("%s falls into the %s!", Monnam(mtmp),

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -95,11 +95,8 @@ long gpflags;
                 return (is_floater(mdat) || is_flyer(mdat)
                         || likes_lava(mdat));
         }
-        if (IS_AIR(levl[x][y].typ) && In_V_tower(&u.uz)
-            && !(is_flyer(mdat) || is_floater(mdat)
-                 || is_clinger(mdat))
-            && !ignoreair)
-            return FALSE;
+        if (IS_AIR(levl[x][y].typ) && In_V_tower(&u.uz) && !ignoreair)
+            return (is_flyer(mdat) || is_floater(mdat) || is_clinger(mdat));
         if (passes_walls(mdat) && may_passwall(x, y))
             return TRUE;
         if (amorphous(mdat) && closed_door(x, y))

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -77,7 +77,7 @@ long gpflags;
                 return (is_swimmer(mdat)
                         || (!Is_waterlevel(&u.uz)
                             && (is_floater(mdat) || is_flyer(mdat)
-                                || ceiling_hider(mdat))));
+                                || is_clinger(mdat))));
         } else if (mdat->mlet == S_EEL && rn2(13) && !ignorewater
                    && !is_puddle(x, y)) {
             return FALSE;
@@ -97,7 +97,7 @@ long gpflags;
         }
         if (IS_AIR(levl[x][y].typ) && In_V_tower(&u.uz)
             && !(is_flyer(mdat) || is_floater(mdat)
-                 || ceiling_hider(mdat))
+                 || is_clinger(mdat))
             && !ignoreair)
             return FALSE;
         if (passes_walls(mdat) && may_passwall(x, y))

--- a/src/trap.c
+++ b/src/trap.c
@@ -580,7 +580,7 @@ unsigned ftflags;
         ; /* KMH -- You can't escape the Sokoban level traps */
     else if (Levitation || u.ustuck
              || (!Can_fall_thru(&u.uz) && !levl[u.ux][u.uy].candig)
-             || ((Flying || ceiling_hider(youmonst.data)
+             || ((Flying || is_clinger(youmonst.data)
                   || maybe_polyd(is_giant(youmonst.data), Race_if(PM_GIANT))
                   || (ceiling_hider(youmonst.data) && u.uundetected))
                  && !(ftflags & TOOKPLUNGE))
@@ -606,7 +606,7 @@ unsigned ftflags;
         }
         return;
     }
-    if ((Flying || ceiling_hider(youmonst.data)
+    if ((Flying || is_clinger(youmonst.data)
         || maybe_polyd(is_giant(youmonst.data), Race_if(PM_GIANT)))
         && (ftflags & TOOKPLUNGE) && td && t)
         You("%s down %s!",
@@ -1087,7 +1087,7 @@ unsigned trflags;
             && ttype != ANTI_MAGIC && !forcebungle && !plunged
             && !conj_pit && !adj_pit
             && (!rn2(5) || (is_pit(ttype)
-                            && ceiling_hider(youmonst.data)))) {
+                            && is_clinger(youmonst.data)))) {
                 You("escape %s %s.", (ttype == ARROW_TRAP && !trap->madeby_u)
                                      ? "an"
                                      : a_your[trap->madeby_u],
@@ -1378,7 +1378,7 @@ unsigned trflags;
         if (!Sokoban && (Levitation || (Flying && !plunged)))
             break;
         feeltrap(trap);
-        if (!Sokoban && ceiling_hider(youmonst.data) && !plunged) {
+        if (!Sokoban && is_clinger(youmonst.data) && !plunged) {
             if (trap->tseen) {
                 You_see("%s %spit below you.", a_your[trap->madeby_u],
                         ttype == SPIKED_PIT ? "spiked " : "");
@@ -1475,7 +1475,7 @@ unsigned trflags;
             } else {
                 /* plunging flyers take spike damage but not pit damage */
                 if (!conj_pit
-                    && !(plunged && (Flying || ceiling_hider(youmonst.data))))
+                    && !(plunged && (Flying || is_clinger(youmonst.data))))
                     losehp(Maybe_Half_Phys(rnd(adj_pit ? 3 : 6)),
                            plunged ? "deliberately plunged into a pit"
                                    : "fell into a pit",
@@ -2813,7 +2813,7 @@ register struct monst *mtmp;
             fallverb = "falls";
             if (is_flyer(mptr) || is_floater(mptr)
                 || (mtmp->wormno && count_wsegs(mtmp) > 5)
-                || ceiling_hider(mptr)) {
+                || is_clinger(mptr)) {
                 if (force_mintrap && !Sokoban) {
                     /* openfallingtrap; not inescapable here */
                     if (in_sight) {
@@ -3535,7 +3535,7 @@ climb_pit()
         display_nhwindow(WIN_MESSAGE, FALSE);
         clear_nhwindow(WIN_MESSAGE);
         You("free your %s.", body_part(LEG));
-    } else if ((Flying || ceiling_hider(youmonst.data)) && !Sokoban) {
+    } else if ((Flying || is_clinger(youmonst.data)) && !Sokoban) {
         /* eg fell in pit, then poly'd to a flying monster;
            or used '>' to deliberately enter it */
         You("%s from the pit.", Flying ? "fly" : "climb");


### PR DESCRIPTION
- Revert "Fix: large/giant mimics spawning or travelling where they shouldn't."
- Revert "Fix: wumpus movement over water/lava and open air in Vlad's cavern."
- Handle air/liquid when choosing mimic disguise

This is pretty much what I was suggesting on IRC. I don't think there's a very
appropriate disguise available for a mimic while it's clinging to the ceiling,
so this just sets them to retain their normal form while clinging to the
ceiling.  Maybe there's a better ceiling-clinging disguise option?
