### PR TITLE
Adjustments to racial abilities.

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -1020,6 +1020,7 @@ int how;
        reducing ulevel below 1, but include this for bulletproofing */
     if (u.ulevel < 1)
         u.ulevel = 1;
+        adjabil(0,1); // since level-draining would have lost them
     uhpmin = max(2 * u.ulevel, 10);
     if (u.uhpmax < uhpmin)
         u.uhpmax = uhpmin;

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -63,14 +63,7 @@ set_uasmon()
     PROPSET(ACID_RES, resists_acid(&youmonst));
     PROPSET(STONE_RES, resists_ston(&youmonst));
     PROPSET(PSYCHIC_RES, resists_psychic(&youmonst));
-    {
-        /* resists_drli() takes wielded weapon into account; suppress it */
-        struct obj *save_uwep = uwep;
-
-        uwep = 0;
-        PROPSET(DRAIN_RES, resists_drli(&youmonst));
-        uwep = save_uwep;
-    }
+    PROPSET(DRAIN_RES, resists_drain(racedat));
     /* Vulnerablilties */
     PROPSET(VULN_FIRE, vulnerable_to(&youmonst, AD_FIRE));
     PROPSET(VULN_COLD, vulnerable_to(&youmonst, AD_COLD));
@@ -2060,7 +2053,7 @@ polysense()
     context.warntype.speciesidx = NON_PM;
     context.warntype.species = 0;
     context.warntype.polyd = 0;
-    HWarn_of_mon &= ~FROMRACE;
+    HWarn_of_mon &= ~FROMFORM;
 
     switch (u.umonnum) {
     case PM_PURPLE_WORM:
@@ -2071,13 +2064,13 @@ polysense()
     case PM_VAMPIRE_ROYAL:
     case PM_VAMPIRE_MAGE:
         context.warntype.polyd = MH_HUMAN | MH_ELF;
-        HWarn_of_mon |= FROMRACE;
+        HWarn_of_mon |= FROMFORM;
         return;
     }
     if (warnidx >= LOW_PM) {
         context.warntype.speciesidx = warnidx;
         context.warntype.species = &mons[warnidx];
-        HWarn_of_mon |= FROMRACE;
+        HWarn_of_mon |= FROMFORM;
     }
 }
 

--- a/src/pray.c
+++ b/src/pray.c
@@ -811,31 +811,23 @@ gcrownu()
     xchar maxint, maxwis;
 #define ok_wep(o) ((o) && ((o)->oclass == WEAPON_CLASS || is_weptool(o)))
 
-    HSee_invisible |= FROMOUTSIDE;
-    /* small chance to obtain sick resistance, but not
-       this way if infidel (see below) */
-    if (!rn2(10) && !Role_if(PM_INFIDEL))
-        HSick_resistance |= FROMOUTSIDE;
-    incr_resistance(&HFire_resistance, 100);
-    if (!Role_if(PM_INFIDEL)) {
-        /* demons don't get all the intrinsics */
+    /* Moloch-worshippers get intrinsics from becoming a demon*/
+    if (u.ualign.type != A_NONE) {
+        incr_resistance(&HFire_resistance, 100);
         incr_resistance(&HCold_resistance, 100);
         incr_resistance(&HShock_resistance, 100);
         incr_resistance(&HSleep_resistance, 100);
-    }
-    incr_resistance(&HPoison_resistance, 100);
-    if (Role_if(PM_INFIDEL)) {
-        HSick_resistance |= FROMRACE;
-        if (Race_if(PM_ILLITHID)) /* demons don't have the correct brain structure */
-            HPsychic_resistance &= ~INTRINSIC;
-        if (Race_if(PM_CENTAUR)) /* demons don't have four legs */
-            EJumping &= ~INTRINSIC;
-    }
-    if (!Role_if(PM_INFIDEL))
+        incr_resistance(&HPoison_resistance, 100);
+        HSee_invisible |= FROMOUTSIDE;
+        /* small chance to obtain sick resistance, but not
+        this way if infidel (see below) */
+        if (!rn2(10))
+            HSick_resistance |= FROMOUTSIDE;
+            
         monstseesu(M_SEEN_FIRE | M_SEEN_COLD | M_SEEN_ELEC
                    | M_SEEN_SLEEP | M_SEEN_POISON);
-    else
-        monstseesu(M_SEEN_FIRE | M_SEEN_POISON);
+    }
+
     godvoice(u.ualign.type, (char *) 0);
 
     class_gift = STRANGE_OBJECT;
@@ -915,7 +907,8 @@ gcrownu()
             P_MAX_SKILL(P_TRIDENT) = P_EXPERT;
             if (Upolyd)
                 rehumanize(); /* return to human/orcish form -- not a demon yet */
-            pline1("Wings sprout from your back and you grow a barbed tail!");
+            /* lose ALL old racial abilities */
+            adjabil(u.ulevel, 0);
             maxint = urace.attrmax[A_INT];
             maxwis = urace.attrmax[A_WIS];
             urace = race_demon;
@@ -923,9 +916,14 @@ gcrownu()
             urace.attrmax[A_INT] = maxint;
             urace.attrmax[A_WIS] = maxwis;
             youmonst.data->msize = MZ_HUMAN; /* in case we started out as a giant */
+            /* gain demonic resistances */
+            adjabil(0, u.ulevel);
+            // move this line so adjabil doesn't flash e.g. warning on and off
+            pline1("Wings sprout from your back and you grow a barbed tail!");
             set_uasmon();
             newsym(u.ux, u.uy);
             retouch_equipment(2); /* silver */
+            monstseesu(M_SEEN_FIRE | M_SEEN_POISON);
             break;
         }
     }


### PR DESCRIPTION
Changes:

0. Original drain res bug fixed. 
1. Fixed the flow of gcrownu so lawful infidels don't get a weird mix of infidel/lawful crowning: all of the changes related to demonic transformation happen in one place. 
2. Updated unaligned (a.k.a. infidel) crowning to properly get demon racial abilities. Also removes *all* abilities of previous race, which I think makes sense but may or may not be desired. Drain res and flying remain FROMFORM only (this time intentionally). Sick res is added explicitly as a racial ability---it was added FROMRACE before anyway, so this made things a bit neater. Other intrinsics that demons got (fire res, poison res, see invis) were already supposed to be racial abilities; now that demons get those properly, there is no need to give them explicitly. 
3. Changed lvl 1 racial abilities to be FROMRACE so that other sources of intrinsic gain can be tracked for infidel crowning (e.g. so that an illithid can eat a floating eye and remain telepathic after crowning). Added a line in end.c to make sure these abilities were never lost via level drain to 0 or below, which I *think* is the only place this change had any possible negative side effects though that shouldn't happen. This does mean that, for example, illithids get the mental acuity message when first eating a floating eye corpse, which might be confusing. However, level 17+ wizards have always gotten a message when gaining teleport control from a corpse, which I think is analogous. 
4. Minor other edits to racial abilities for consistency: giants, dwarves, and gnomes weren't getting intrinsic infravison, just FROMFORM, due to two unrelated bugs. Also, FROMRACE was used erroneously in polyself.c (probably not an issue, but why not be safe?). 