### PR TITLE
Whips & Fire Damage

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -3067,7 +3067,11 @@ struct obj *obj;
         There("is too much resistance to flick your bullwhip.");
 
     } else if (u.dz < 0) {
-        You("flick a bug off of the %s.", ceiling(u.ux, u.uy));
+        /* ~Grammar~ */
+        const char *ceil_prep = (ceiling(u.ux, u.uy) == "sky"
+                                 || ceiling(u.ux, u.uy) == "water above") ?
+                                "out" : "off";
+        You("flick a bug %s of the %s.", ceil_prep, ceiling(u.ux, u.uy));
 
     } else if ((!u.dx && !u.dy) || (u.dz > 0)) {
         int dam;
@@ -3078,16 +3082,30 @@ struct obj *obj;
             kick_steed();
             return 1;
         }
-        if (Levitation || u.usteed) {
-            /* Have a shot at snaring something on the floor */
+        /* arguably this whole if statement should be done away with.
+         * why shouldn't you be able to pick up something when you're
+         * just standing on the square? */
+        if (Levitation || Flying || u.usteed || !grounded(youmonst.data)
+            || (Wwalking && (is_pool_or_lava(u.ux, u.uy)))) {
+            /* bullwhips and lava don't mix (usually) */
+            if (is_lava(u.ux, u.uy))
+                // lava_damage() gives feedback which works surprisingly well
+                if (lava_damage(obj, u.ux, u.uy))
+                    return 0;
+
+            /* try to grab something */
             otmp = level.objects[u.ux][u.uy];
             if (otmp && otmp->otyp == CORPSE && otmp->corpsenm == PM_HORSE) {
                 pline("Why beat a dead horse?");
                 return 1;
             }
             if (otmp && proficient) {
-                You("wrap your bullwhip around %s on the %s.",
-                    an(singular(otmp, xname)), surface(u.ux, u.uy));
+                /* objects lie *in* water, lava, or sewage. 'on the fountain'
+                 * sounds a bit weird, but the object isn't in the fountain,
+                 * or else it would be wet. */
+                const char *surf_prep = is_damp_terrain(u.ux, u.uy) ? "in" : "on";
+                You("wrap your bullwhip around %s %s the %s.",
+                    an(singular(otmp, xname)), surf_prep, surface(u.ux, u.uy));
                 if (rnl(6) || pickup_object(otmp, 1L, TRUE) < 1)
                     pline1(msg_slipsfree);
                 return 1;

--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -2006,7 +2006,17 @@ register struct obj *otmp;
         || otmp->oartifact == ART_HAND_OF_VECNA)
         return FALSE;
 
-    if (objects[otyp].oc_oprop == FIRE_RES || otyp == WAN_FIRE)
+    /* fire-related items are immune*/
+    if (objects[otyp].oc_oprop == FIRE_RES || otyp == WAN_FIRE
+        || otyp == SCR_FIRE || otyp == SPE_FIREBALL || otyp == FIRE_HORN)
+        return FALSE;
+    else if (attacks(AD_FIRE, otmp) || defends(AD_FIRE, otmp))
+        return FALSE;
+    /* weapons of fire are handled above; armor is not*/
+    else if (otmp->oprops  && otmp->oprops & ITEM_FIRE)
+        return FALSE;
+
+    if (otyp == SPE_BOOK_OF_THE_DEAD)
         return FALSE;
 
     return (boolean) ((omat <= BONE && omat != LIQUID) || omat == PLASTIC);


### PR DESCRIPTION
I noticed that you couldn't apply whips to pull objects out of water when flying, and when I was checking why I noticed that there was nothing stopping you from applying a leather whip into lava and pulling it out unharmed, which led to me noticing that items with fire oprops could be burnt, and assorted other fire items didn't seem to be handled consistently by the various fire damage functions. These commits would make the use of whips a bit more intuitive, and make the fire_damage and lava_damage functions a bit less idiosyncratic by relying more consistently on is_flammable. They are mostly independent commits, but the whip commit does rely on some minor changes in lava_damage to give grammatical feedback that I put in the other commit. 