### PR TITLE
Fix: Drow objects breaking based on incorrect position info

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -622,7 +622,7 @@ E int FDECL(hero_breaks, (struct obj *, XCHAR_P, XCHAR_P, unsigned));
 E int FDECL(breaks, (struct obj *, XCHAR_P, XCHAR_P));
 E void FDECL(release_camera_demon, (struct obj *, XCHAR_P, XCHAR_P));
 E void FDECL(breakobj, (struct obj *, XCHAR_P, XCHAR_P, BOOLEAN_P, BOOLEAN_P));
-E boolean FDECL(breaktest, (struct obj *));
+E boolean FDECL(breaktest, (struct obj *, XCHAR_P, XCHAR_P));
 E void FDECL(breakmsg, (struct obj *, BOOLEAN_P));
 E boolean FDECL(walk_path, (coord *, coord *,
                             boolean (*)(genericptr, int, int), genericptr_t));

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -1721,13 +1721,15 @@ boolean shop_floor_obj;
         remove_worn_item(otmp, TRUE);
 
     /* some things break rather than ship */
-    if (breaktest(otmp)) {
+    if (breaktest(otmp, cc.x, cc.y)) {
         const char *result;
 
         if (otmp->material == GLASS || otmp->otyp == EXPENSIVE_CAMERA) {
             if (otmp->otyp == MIRROR)
                 change_luck(-2);
             result = "crash";
+        } else if (otmp->material == ADAMANTINE) {
+            result = "crumbling sound";
         } else {
             /* penalty for breaking eggs laid by you */
             if (otmp->otyp == EGG && otmp->spe && otmp->corpsenm >= LOW_PM)
@@ -1816,7 +1818,7 @@ boolean near_hero;
                 if (where == MIGR_WITH_HERO) {
                     if (breaks(otmp, nx, ny))
                         continue;
-                } else if (breaktest(otmp)) {
+                } else if (breaktest(otmp, nx, ny)) {
                     /* assume it broke before player arrived, no messages */
                     delobj(otmp);
                     continue;
@@ -1831,7 +1833,7 @@ boolean near_hero;
             /* set dummy coordinates because there's no
                current position for rloco() to update */
             otmp->ox = otmp->oy = 0;
-            if (rloco(otmp) && !nobreak && breaktest(otmp)) {
+            if (rloco(otmp) && !nobreak && breaktest(otmp, otmp->ox, otmp->oy)) {
                 /* assume it broke before player arrived, no messages */
                 delobj(otmp);
             }

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -2448,16 +2448,6 @@ breaktest(obj, x, y)
 struct obj *obj;
 xchar x, y;
 {
-    //xchar x, y;
-
-    /* establish the 'where' for spot_is_dark () */
-    /*if (mcarried(obj)) {
-        x = obj->ocarry->mx, y = obj->ocarry->my;
-    } else if (carried(obj)) {
-        x = u.ux, y = u.uy;
-    } else {
-        x = obj->ox, y = obj->oy;
-    }*/
     if (obj_resists(obj, 1, 99))
         return 0;
     if (obj->material == GLASS && !obj->oerodeproof

--- a/src/hack.c
+++ b/src/hack.c
@@ -1816,7 +1816,7 @@ domove_core()
         struct obj *obj = uwep;
         unsigned breakflags = (BRK_BY_HERO | BRK_FROM_INV);
 
-        if (breaktest(obj)) {
+        if (breaktest(obj, u.ux, u.uy)) {
             if (obj->quan > 1L)
                 obj = splitobj(obj, 1L);
             else
@@ -2604,7 +2604,7 @@ boolean pick;
                 You("are almost hit by %s!",
                     x_monnam(mtmp, ARTICLE_A, "falling", 0, TRUE));
             } else if (uarmh) {
-                if (breaktest(uarmh) && (mtmp->data == &mons[PM_GLASS_PIERCER]
+                if (breaktest(uarmh, u.ux, u.uy) && (mtmp->data == &mons[PM_GLASS_PIERCER]
                                          && uarmh->material == GLASS)) {
                     struct obj* helm = uarmh;
                     pline("It pierces and shatters your helm!");

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -183,7 +183,7 @@ int x, y;
                     && is_pit(t->ttyp))) {
         int objgone = 0;
 
-        if (!IS_SOFT(levl[x][y].typ) && breaktest(obj)) {
+        if (!IS_SOFT(levl[x][y].typ) && breaktest(obj, x, y)) {
             breakmsg(obj, cansee(x, y));
             breakobj(obj, x, y, FALSE, FALSE);
             objgone = 1;

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1359,7 +1359,7 @@ int dieroll;
                     }
                     break;
                 case MIRROR:
-                    if (breaktest(obj)) {
+                    if (breaktest(obj, u.ux, u.uy)) {
                         You("break %s.  That's bad luck!", ysimple_name(obj));
                         change_luck(-2);
                         useup(obj);


### PR DESCRIPTION
Thrown objects (and possibly others?) were being evaluated for breakability based on where they were last dropped, not where they were being thrown. 