### PR TITLE
fix: thrown fragile weapons hitting monsters

### DIFF
--- a/doc/evilhack-changelog.md
+++ b/doc/evilhack-changelog.md
@@ -2903,4 +2903,4 @@ The following changes to date are:
 - Fix: Angelslayer's chance of special attack worked with other fire-based
   weapons
 - Fix: drow objects breaking based on incorrect position info
-
+- Fix: thrown fragile objects hitting monsters

--- a/include/extern.h
+++ b/include/extern.h
@@ -624,6 +624,7 @@ E void FDECL(release_camera_demon, (struct obj *, XCHAR_P, XCHAR_P));
 E void FDECL(breakobj, (struct obj *, XCHAR_P, XCHAR_P, BOOLEAN_P, BOOLEAN_P));
 E boolean FDECL(breaktest, (struct obj *, XCHAR_P, XCHAR_P));
 E void FDECL(breakmsg, (struct obj *, BOOLEAN_P));
+E boolean FDECL(break_glass_obj, (struct obj *));
 E boolean FDECL(walk_path, (coord *, coord *,
                             boolean (*)(genericptr, int, int), genericptr_t));
 E boolean FDECL(hurtle_jump, (genericptr_t, int, int));
@@ -2808,7 +2809,6 @@ E void FDECL(missum, (struct monst *, int, int, struct attack *, BOOLEAN_P));
 E int FDECL(passive, (struct monst *, struct obj *, BOOLEAN_P, int,
                       UCHAR_P, BOOLEAN_P));
 E int FDECL(passive_obj, (struct monst *, struct obj *, struct attack *));
-E boolean FDECL(break_glass_obj, (struct obj *));
 E void FDECL(stumble_onto_mimic, (struct monst *));
 E int FDECL(flash_hits_mon, (struct monst *, struct obj *));
 E void FDECL(light_hits_light_hater, (struct monst *, int));

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -2299,7 +2299,7 @@ unsigned breakflags;
     /* from_invent: thrown or dropped by player; maybe on shop bill;
        by-hero is implicit so callers don't need to specify BRK_BY_HERO */
     boolean from_invent = (breakflags & BRK_FROM_INV) != 0,
-            in_view = Blind ? FALSE : (from_invent || cansee(x, y));
+            in_view = Blind ? FALSE : cansee(x, y);
     unsigned brk = (breakflags & BRK_KNOWN_OUTCOME);
 
     /* only call breaktest if caller hasn't already specified the outcome */
@@ -2448,14 +2448,15 @@ breaktest(obj, x, y)
 struct obj *obj;
 xchar x, y;
 {
-    if (obj_resists(obj, 1, 99))
+    if (!obj || obj_resists(obj, 1, 99))
         return 0;
     if (obj->material == GLASS && !obj->oerodeproof
         && !obj->oartifact && obj->oclass != GEM_CLASS)
         return 1;
     /* Drow objects are brittle if in the light */
     if (obj->material == ADAMANTINE && is_drow_obj(obj)
-        && !obj->oartifact && !spot_is_dark(x, y))
+        && !obj->oartifact && !spot_is_dark(x, y)
+        && (is_drow_weapon(obj) ? !rn2(16) : !rn2(6)))
         return 1;
     switch (obj->oclass == POTION_CLASS ? POT_WATER : obj->otyp) {
     case EXPENSIVE_CAMERA:
@@ -2571,9 +2572,7 @@ struct obj* obj;
     }
 
     if (!breaktest(obj, x, y)
-        || spit_object(obj)
-        || (obj->material == ADAMANTINE
-            && is_drow_weapon(obj) ? rn2(16) : rn2(6)))
+        || spit_object(obj))
         return FALSE;
     /* now we are definitely breaking it */
 

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -2299,7 +2299,7 @@ unsigned breakflags;
     /* from_invent: thrown or dropped by player; maybe on shop bill;
        by-hero is implicit so callers don't need to specify BRK_BY_HERO */
     boolean from_invent = (breakflags & BRK_FROM_INV) != 0,
-            in_view = Blind ? FALSE : cansee(x, y);
+            in_view = Blind ? FALSE : (from_invent || cansee(x, y));
     unsigned brk = (breakflags & BRK_KNOWN_OUTCOME);
 
     /* only call breaktest if caller hasn't already specified the outcome */

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -2029,7 +2029,8 @@ int dieroll;
 
     /* glass breakage from the attack */
     break_glass_obj(some_armor(mon));
-    if (break_glass_obj(obj)) {
+    if ((hand_to_hand && break_glass_obj(obj))
+        || hero_breaks(obj, mon->mx, mon->my, 0)) {
         obj->opoisoned = 0;
         obj->otainted = 0;
         obj = (struct obj *) 0;


### PR DESCRIPTION
Throwing weapons at monsters called break_glass_obj, which assumed that the object was carried. This was largely unnoticable before the last few commits, since fragile items were rarely thrown at monsters. Now, the functions does things in a different order and it happens all the time. Instead, call one of the other breaking functions for thrown and kicked weapons.

Also, move the drow chance of resisting breakage to breaktest()---on further consideration, I thought that only having the chance to resist breakage on melee attacks didn't make much sense. Now, drow stuff has the same chance of not crumbling when thrown/kicked/etc.

Other stuff:
Moved a function declaration.
Check if breaktest() is actually given an object to test. 