### PR TITLE
Make elemental vulnerability more consistent

### DIFF
--- a/src/explode.c
+++ b/src/explode.c
@@ -486,18 +486,9 @@ int expltype;
                        gets hit by double damage */
                     if (grabbed && mtmp == u.ustuck && distu(x, y) <= 2)
                         mdam *= 2;
-                    /* being resistant to opposite type of damage makes
-                       target more vulnerable to current type of damage
-                       (when target is also resistant to current type,
-                       we won't get here) */
-                    if (resists_cold(mtmp) && adtyp == AD_FIRE)
-                        mdam *= 2;
-                    else if (resists_fire(mtmp) && adtyp == AD_COLD)
-                        mdam *= 2;
                     if (mon_underwater(mtmp)
                         && (adtyp == AD_FIRE || adtyp == AD_ACID))
                         mdam = rnd(3); /* physical damage only */
-
                     damage_mon(mtmp, mdam, adtyp);
                     damage_mon(mtmp, idamres + idamnonres, adtyp);
                 }

--- a/src/zap.c
+++ b/src/zap.c
@@ -4280,8 +4280,6 @@ struct obj **ootmp; /* to return worn armor for caller to disintegrate */
             break;
         }
         tmp = d(nd, 6);
-        if (resists_cold(mon))
-            tmp += 7;
         if (spellcaster)
             tmp = spell_damage_bonus(tmp);
         if (burnarmor(mon)) {
@@ -4300,8 +4298,6 @@ struct obj **ootmp; /* to return worn armor for caller to disintegrate */
             break;
         }
         tmp = d(nd, 6);
-        if (resists_fire(mon))
-            tmp += d(nd, 3);
         if (spellcaster)
             tmp = spell_damage_bonus(tmp);
         if (!rn2(3))
@@ -4472,6 +4468,10 @@ struct obj **ootmp; /* to return worn armor for caller to disintegrate */
         tmp /= 2;
     if (tmp < 0)
         tmp = 0; /* don't allow negative damage */
+    /* have to do vulnerability here because we need to return tmp.
+       damage_mon() wouldn't tell us if tmp is increased. */
+    if (vulnerable_to(mon, abstype + 1))
+        tmp = ((3 * tmp) + 1) / 2;
     debugpline3("zapped monster hp = %d (= %d - %d)", mon->mhp - tmp,
                 mon->mhp, tmp);
     mon->mhp -= tmp;


### PR DESCRIPTION
Evilhack added flags for vulnerability to fire/cold/acid/electricity, but didn't always consult them. Also, there were some leftovers from vanilla's ad hoc vulnerability system. Remove the leftovers and make sure vulnerability is considered in melee and ray attacks.