### PR TITLE
Some light edits to light code

### DIFF
--- a/src/light.c
+++ b/src/light.c
@@ -597,15 +597,16 @@ void
 snuff_light_source(x, y)
 int x, y;
 {
-    light_source *ls;
+    light_source *ls, *ls_next;
     struct obj *obj;
 
-    for (ls = light_base; ls; ls = ls->next)
+    for (ls = light_base; ls; ls = ls_next) {
         /*
          * Is this position check valid??? Can I assume that the positions
          * will always be correct because the objects would have been
          * updated with the last vision update?  [Is that recent enough???]
          */
+        ls_next = ls->next;
         if (ls->type == LS_OBJECT && ls->x == x && ls->y == y) {
             obj = ls->id.a_obj;
             if (obj_is_burning(obj)) {
@@ -622,14 +623,9 @@ int x, y;
                         && Dragon_armor_to_scales(obj) == SHADOW_DRAGON_SCALES))
                     continue;
                 end_burn(obj, obj->otyp != MAGIC_LAMP);
-                /*
-                 * The current ls element has just been removed (and
-                 * ls->next is now invalid).  Return assuming that there
-                 * is only one light source attached to each object.
-                 */
-                return;
             }
         }
+    }
 }
 
 /* Return TRUE if object sheds any light at all. */

--- a/src/read.c
+++ b/src/read.c
@@ -2232,32 +2232,33 @@ xchar x, y;      /* coordinates for centering do_clear_area() */
         int still_lit = 0;
 
         /*
-         * The magic douses lamps,&c too and might curse artifact lights.
-         *
-         * FIXME?
-         *  Shouldn't this affect all lit objects in the area of effect
-         *  rather than just those carried by the hero?
+         * The magic douses lamps,&c too and might curse artifact lights,
+         * if the player is in the area of affect.
          */
+        if (!mon || (distu(x,y) <= 25 && clear_path(x, y, u.ux, u.uy))) {
+            for (otmp = invent; otmp; otmp = otmp->nobj) {
+                boolean lamp = (otmp->otyp == MAGIC_LAMP && otmp->cursed);
+                boolean staff = (otmp->oartifact == ART_STAFF_OF_THE_ARCHMAGI
+                                && !Upolyd && Race_if(PM_DROW));
+                boolean armor = (Is_dragon_armor(otmp)
+                                && Dragon_armor_to_scales(otmp) == SHADOW_DRAGON_SCALES);
 
-        for (otmp = invent; otmp; otmp = otmp->nobj) {
-            boolean lamp = (otmp->otyp == MAGIC_LAMP && otmp->cursed);
-            boolean staff = (otmp->oartifact == ART_STAFF_OF_THE_ARCHMAGI
-                             && !Upolyd && Race_if(PM_DROW));
-            boolean armor = (Is_dragon_armor(otmp)
-                             && Dragon_armor_to_scales(otmp) == SHADOW_DRAGON_SCALES);
+                if (otmp->lamplit) {
+                    if (lamp || staff || armor) {
+                        continue;
+                    } else {
+                        if (!artifact_light(otmp))
+                            (void) snuff_lit(otmp);
+                        else if (!mon)
+                            /* wielded Sunsword or worn shield of light/gold dragon
+                            scales; maybe lower its BUC state if not already
+                            cursed */
+                            impact_arti_light(otmp, TRUE, (boolean) !Blind);
 
-            if (otmp->lamplit && !mon) {
-                if (lamp || staff || armor) {
-                    continue;
-                } else if (artifact_light(otmp)) {
-                    /* wielded Sunsword or worn shield of light/gold dragon
-                        scales; maybe lower its BUC state if not already
-                        cursed */
-                    impact_arti_light(otmp, TRUE, (boolean) !Blind);
+                        if (otmp->lamplit)
+                            ++still_lit;
+                    }
                 }
-
-                    if (otmp->lamplit)
-                        ++still_lit;
             }
         }
 

--- a/src/read.c
+++ b/src/read.c
@@ -2248,19 +2248,16 @@ xchar x, y;      /* coordinates for centering do_clear_area() */
 
             if (otmp->lamplit && !mon) {
                 if (lamp || staff || armor) {
-                    break;
-                } else {
-                    if (!artifact_light(otmp))
-                        (void) snuff_lit(otmp);
-                    else
-                        /* wielded Sunsword or worn shield of light/gold dragon
-                           scales; maybe lower its BUC state if not already
-                           cursed */
-                        impact_arti_light(otmp, TRUE, (boolean) !Blind);
+                    continue;
+                } else if (artifact_light(otmp)) {
+                    /* wielded Sunsword or worn shield of light/gold dragon
+                        scales; maybe lower its BUC state if not already
+                        cursed */
+                    impact_arti_light(otmp, TRUE, (boolean) !Blind);
+                }
 
                     if (otmp->lamplit)
                         ++still_lit;
-                }
             }
         }
 

--- a/src/steal.c
+++ b/src/steal.c
@@ -572,7 +572,7 @@ register struct obj *otmp;
     freed_otmp = add_to_minv(mtmp, otmp);
     /* and we had to defer this until object is in mtmp's inventory */
     if (snuff_otmp)
-        snuff_light_source(mtmp->mx, mtmp->my);
+        end_burn(otmp, TRUE);
     return freed_otmp;
 }
 


### PR DESCRIPTION
Make snuff_light_source actually do something useful. Currently it snuffs a single source (the last lit) on a square, which is silly. Now it snuffs all light sources on the square, as the litroom code seems to expect. The only other place it's called is mpickobj, which should be calling end_burn or maybe snuff_lit instead. I went with end_burn. 

Also, make the inventory-snuffing in litroom only happen if you are standing on a square that is darkened (or lightened, I suppose) by the effect. At first I removed this code from litroom because the do_clear_area() call would take care of your inventory via snuff_light_source, but that calls end_burn (calling snuff_lit causes all sorts of nasty errors that I couldn't figure out), so no message would be given (which feels weird, although it's also the case after the last drow darkness commit https://github.com/k21971/EvilHack/commit/8dcbbecd00f5c32e50ff1e0f3c48d40497af5e11 so maybe it's not a big deal). Now it just has an extra check for proximity and line-of-sight. Also changed a break; to a continue; so that dark sources wouldn't prevent light sources from being snuffed, and changed the order of the code so that the mon/!mon only affects the code regarding artifacts, so that drow darkness will trigger snuff_lit properly. 

Note: currently, blessed light effects would be a little buggy if a monster invoked them---they wouldn't snuff your cursed magic lamps. Currently that can't happen so I left it alone for now. 