### PR TITLE
Fix: Carried glass objects always broke when used

### DIFF
--- a/doc/evilhack-changelog.md
+++ b/doc/evilhack-changelog.md
@@ -2959,4 +2959,4 @@ The following changes to date are:
 - Restore ability spell is now directional
 - Tweak to 'restore ability spell is now directional'
 - Phasing allows escape from being engulfed
-
+- Fix: carried glass objects always broke when used

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -2458,11 +2458,15 @@ xchar x, y;
     if (obj->material == GLASS && !obj->oerodeproof
         && !obj->oartifact && obj->oclass != GEM_CLASS)
         return 1;
-    /* Drow objects are brittle if in the light */
+    /* Drow objects are brittle if in the light.
+     * Drow weapons are a bit sturdier. 
+     * Melee weapons have 1/16 chance of breakage when break_glass_obj
+     * is considered, thrown/kicked/etc. weapons have a 3/8 chance, 
+     * and armor has a 1/6 chance regardless. */
     if (obj->material == ADAMANTINE && is_drow_obj(obj)
-        && !obj->oartifact && !spot_is_dark(x, y)
-        && (is_drow_weapon(obj) ? !rn2(16) : !rn2(6)))
-        return 1;
+        && !obj->oartifact && !spot_is_dark(x, y))
+        if (!is_drow_weapon(obj) || (rn2(8) < 3))
+            return 1;
     switch (obj->oclass == POTION_CLASS ? POT_WATER : obj->otyp) {
     case EXPENSIVE_CAMERA:
     case POT_WATER: /* really, all potions */
@@ -2577,7 +2581,8 @@ struct obj* obj;
     }
 
     if (!breaktest(obj, x, y)
-        || spit_object(obj))
+        || spit_object(obj)
+        || rn2(6)) /* items are subject to less force than when thrown */
         return FALSE;
     /* now we are definitely breaking it */
 


### PR DESCRIPTION
I misread some code for giving carried objects a high chance of resisting breakage, thought it only applied to drow equipment, and moved it to breaktest because I thought drow weapons shouldn't always break when thrown. But this meant glass objects always broke regardless. Move the check back to break_glass_obj so carried objects have a 5/6 chance of resisting. Add a 5/8 chance of resisting for drow weapons in any context, so carried drow weapons have a 1/16 chance of breaking and thrown ones have a 3/8 chance (when in light).