### PR TITLE
Prayer Gifts and Theft

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -449,6 +449,10 @@ struct obj {
 #define bypass_forging_rules(obj) \
     ((obj)->otyp == SADDLE || (obj)->oartifact == ART_MAGICBANE \
      || (obj)->oartifact == ART_DRAGONBANE)
+#define is_magic(obj) \
+                 (((obj)->oprops & ITEM_PROP_MASK) \
+                  || (objects[(obj)->otyp]).oc_magic \
+                  || (obj)->oartifact)
 
 /* 'PRIZE' values override obj->corpsenm so prizes mustn't be object types
    which use that field for monster type (or other overloaded purpose) */

--- a/src/detect.c
+++ b/src/detect.c
@@ -235,11 +235,6 @@ boolean magic;
     }
 }
 
-#define is_magic(obj) \
-                 (((obj)->oprops & ITEM_PROP_MASK) \
-                  || (objects[(obj)->otyp]).oc_magic \
-                  || (obj)->oartifact)
-
 /* Check whether the location has an outdated object displayed on it. */
 STATIC_OVL boolean
 check_map_spot(x, y, oclass, material, magic)

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -2172,9 +2172,19 @@ post_stone:
         if (magr->mcan)
             break;
         /* find an object to steal, non-cursed if magr is tame */
+        int inv_tmp = 0;
         for (obj = mdef->minvent; obj; obj = obj->nobj) {
             if (!magr->mtame || !obj->cursed)
-                break;
+                ++inv_tmp;
+        }
+        if (inv_tmp)
+            inv_tmp = rnd(inv_tmp);
+        for (obj = mdef->minvent; obj; obj = obj->nobj) {
+            if (!magr->mtame || !obj->cursed) {
+                --inv_tmp;
+                if (inv_tmp < 1)
+                    break;
+            }
         }
 
         if (obj) {

--- a/src/pray.c
+++ b/src/pray.c
@@ -2308,7 +2308,8 @@ dosacrifice()
                             newsym(u.ux, u.uy);
                         }
                         godvoice(u.ualign.type, "Use this gift skillfully!");
-                        u.ugifts++;
+                        if (!otmp || is_magic(otmp))
+                            u.ugifts++;
                         u.ublesscnt = rnz(300 + (50 * u.ugifts));
                         exercise(A_WIS, TRUE);
                         if (!Hallucination && !Blind) {
@@ -2501,7 +2502,8 @@ dosacrifice()
                             else
                                 godvoice(u.ualign.type,
                                          "Use this gift valorously!");
-                            u.ugifts++;
+                            if (is_magic(otmp))
+                                u.ugifts++;
                             u.ublesscnt = rnz(300 + (50 * u.ugifts));
                             exercise(A_WIS, TRUE);
                             if (!Hallucination && !Blind) {

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -2399,7 +2399,7 @@ struct attack *mattk;
     }
 
     /* greased objects are difficult to get a grip on, hence
-    the odds that an attempt at stealing it may fail */
+       the odds that an attempt at stealing it may fail */
     if (otmp && (otmp->greased || otmp->otyp == OILSKIN_CLOAK
         || otmp->otyp == OILSKIN_SACK
         || otmp->oartifact == ART_BAG_OF_THE_HESPERIDES
@@ -2599,8 +2599,8 @@ struct attack *mattk;
                     mhis(mdef));
 
         /* only triggered if (stealoid && items have already been stolen).
-        failing to steal a greased object will stop you from stealing 
-        anything else to avoid infinite loop nastiness */
+           failing to steal a greased object will stop you from stealing 
+           anything else to avoid infinite loop nastiness */
         if (otmp && (otmp->greased || otmp->otyp == OILSKIN_CLOAK
             || otmp->otyp == OILSKIN_SACK
             || otmp->oartifact == ART_BAG_OF_THE_HESPERIDES
@@ -2654,14 +2654,14 @@ struct attack *mattk;
     /* only train thievery if you have the skill */
     if (Role_if(PM_ROGUE) || Role_if(PM_CONVICT)) {
         /* train the skill here instead of in hmon_hitmon() to avoid premature
-        messages about feeling more dangerous when theft fails */
+           messages about feeling more dangerous when theft fails */
         use_skill(P_THIEVERY, 1);
 
         /* Training up thievery skill can be quite the chore, to the point
-        where many players don't bother to use it. Randomly add an
-        additional point of skill for a successful attempt to balance
-        out the drudgery, without having to revamp how skill points are
-        awarded for this specific skill */
+           where many players don't bother to use it. Randomly add an
+           additional point of skill for a successful attempt to balance
+           out the drudgery, without having to revamp how skill points are
+           awarded for this specific skill */
         if (rn2(3)) /* 66% chance in favor of the player */
             use_skill(P_THIEVERY, 1);
     }

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1121,11 +1121,6 @@ int dieroll;
         thievery = ((Role_if(PM_ROGUE) || Role_if(PM_CONVICT))
                     && context.forcefight && !Upolyd);
 
-        /* don't increment thievery skill for regular bare handed attacks */
-        if (!uwep && (Role_if(PM_ROGUE) || Role_if(PM_CONVICT))
-            && !context.forcefight)
-            use_skill(P_THIEVERY, -1);
-
         /* monks have a chance to break their opponents wielded weapon
          * under certain conditions */
         if ((dieroll == 5 && unarmed
@@ -1709,7 +1704,9 @@ int dieroll;
         tmp += weapon_dam_bonus(wep);
         /* [this assumes that `!thrown' implies wielded...] */
         wtype = thrown ? weapon_type(wep) : uwep_skill_type();
-        use_skill(wtype, 1);
+        /* train thievery in steal_it() when we know if theft succeeded */
+        if (!(!uwep && (Role_if(PM_ROGUE) || Role_if(PM_CONVICT))))
+            use_skill(wtype, 1);
     }
 
     if (!ispotion && obj /* potion obj will have been freed by here */
@@ -1821,7 +1818,6 @@ int dieroll;
             && !strcmp(shkname(mon), "Izchak")) {
             You("find yourself unable to steal from %s.",
                 mon_nam(mon));
-            use_skill(P_THIEVERY, -1);
             return 0;
         }
         /* pets are also off-limits, since #loot can be
@@ -1831,13 +1827,11 @@ int dieroll;
         if (mon->mtame) {
             You_cant("bring yourself to steal from %s.",
                 mon_nam(mon));
-            use_skill(P_THIEVERY, -1);
             return 0;
         }
         /* engulfed? ummm no */
         if (u.uswallow) {
             pline("What exactly were you planning on stealing?  Its stomach?");
-            use_skill(P_THIEVERY, -1);
             return 0;
         }
         if (mon->minvent != 0) {
@@ -1849,8 +1843,6 @@ int dieroll;
         } else if (mon->minvent == 0) {
             pline("%s has nothing for you to %s.",
                   Monnam(mon), rn2(2) ? "steal" : "pickpocket");
-            /* prevent skill from incrementing - nothing was stolen */
-            use_skill(P_THIEVERY, -1);
         }
         hittxt = TRUE;
     } else if (!already_killed)
@@ -2360,28 +2352,6 @@ struct attack *mattk;
     if (!otmp || (as_mon && otmp->oclass == COIN_CLASS && !otmp->nobj))
         return; /* nothing to take */
 
-    /* greased objects are difficult to get a grip on, hence
-       the odds that an attempt at stealing it may fail */
-    if (otmp && (otmp->greased || otmp->otyp == OILSKIN_CLOAK
-        || otmp->otyp == OILSKIN_SACK
-        || otmp->oartifact == ART_BAG_OF_THE_HESPERIDES
-        || (otmp->oprops & ITEM_OILSKIN))
-        && (!otmp->cursed || rn2(4))) {
-        Your("%s slip off of %s %s %s!",
-              makeplural(body_part(HAND)),
-              s_suffix(mon_nam(mdef)),
-              otmp->greased ? "greased" : "slippery",
-              (otmp->greased || objects[otmp->otyp].oc_name_known)
-                  ? xname(otmp)
-                  : cloak_simple_name(otmp));
-
-        if (otmp->greased && !rn2(2)) {
-            pline_The("grease wears off.");
-            otmp->greased = 0;
-        }
-        return;
-    }
-
     /* look for worn body armor */
     stealoid = (struct obj *) 0;
     if (as_mon) {
@@ -2401,15 +2371,6 @@ struct attack *mattk;
         gold = findgold(mdef->minvent, TRUE);
     }
 
-    if (stealoid) { /* we will be taking everything */
-        if (gender(mdef) == (int) u.mfemale && youmonst.data->mlet == S_NYMPH)
-            You("charm %s.  She gladly hands over %sher possessions.",
-                mon_nam(mdef), !gold ? "" : "most of ");
-        else
-            You("seduce %s and %s starts to take off %s clothes.",
-                mon_nam(mdef), mhe(mdef), mhis(mdef));
-    }
-
     /* prevent gold from being stolen so that steal-item isn't a superset
        of steal-gold; shuffling it out of minvent before selecting next
        item, and then back in case hero or monster dies (hero touching
@@ -2418,6 +2379,46 @@ struct attack *mattk;
        taking it out once and then trying to figure out how to put it back */
     if (as_mon && gold)
         obj_extract_self(gold);
+
+    if (stealoid) { /* we will be taking everything */
+        if (gender(mdef) == (int) u.mfemale && youmonst.data->mlet == S_NYMPH)
+            You("charm %s.  She gladly hands over %sher possessions.",
+                mon_nam(mdef), !gold ? "" : "most of ");
+        else
+            You("seduce %s and %s starts to take off %s clothes.",
+                mon_nam(mdef), mhe(mdef), mhis(mdef));
+        otmp = mdef->minvent;
+    } else { /* if only one object is taken, randomize it */
+        int tmp = 0;
+        for (otmp = mdef->minvent; otmp; otmp = otmp->nobj) {
+            ++tmp;
+        }
+        tmp = rnd(tmp);
+        for (otmp = mdef->minvent; tmp > 1; --tmp)
+            otmp = otmp->nobj;
+    }
+
+    /* greased objects are difficult to get a grip on, hence
+    the odds that an attempt at stealing it may fail */
+    if (otmp && (otmp->greased || otmp->otyp == OILSKIN_CLOAK
+        || otmp->otyp == OILSKIN_SACK
+        || otmp->oartifact == ART_BAG_OF_THE_HESPERIDES
+        || (otmp->oprops & ITEM_OILSKIN))
+        && (!otmp->cursed || rn2(4))) {
+        Your("%s slip off of %s %s %s!",
+              makeplural(body_part(HAND)),
+              s_suffix(mon_nam(mdef)),
+              otmp->greased ? "greased" : "slippery",
+              (otmp->greased || objects[otmp->otyp].oc_name_known)
+                  ? xname(otmp)
+                  : cloak_simple_name(otmp));
+
+        if (otmp->greased && !rn2(2)) {
+            pline_The("grease wears off.");
+            otmp->greased = 0;
+        }
+        return;
+    }
 
     /* Rogues and Convicts can use the thievery skill;
        dexterity directly affects how successful a
@@ -2587,22 +2588,47 @@ struct attack *mattk;
                 }
             }
         }
-        /* don't increment the skill if the attempt isn't successful */
-        use_skill(P_THIEVERY, -1);
         return;
     }
 
-    while ((otmp = mdef->minvent) != 0) {
+    while (stealoid ? (otmp = mdef->minvent) : otmp) {
         if (gold) /* put 'mdef's gold back after remembering mdef->minvent */
             mpickobj(mdef, gold), gold = 0;
         if (otmp == stealoid) /* special message for final item */
             pline("%s finishes taking off %s suit.", Monnam(mdef),
                     mhis(mdef));
+
+        /* only triggered if (stealoid && items have already been stolen).
+        failing to steal a greased object will stop you from stealing 
+        anything else to avoid infinite loop nastiness */
+        if (otmp && (otmp->greased || otmp->otyp == OILSKIN_CLOAK
+            || otmp->otyp == OILSKIN_SACK
+            || otmp->oartifact == ART_BAG_OF_THE_HESPERIDES
+            || (otmp->oprops & ITEM_OILSKIN))
+            && (!otmp->cursed || rn2(4))) {
+            Your("%s slip off of %s %s %s!",
+                makeplural(body_part(HAND)),
+                s_suffix(mon_nam(mdef)),
+                otmp->greased ? "greased" : "slippery",
+                (otmp->greased || objects[otmp->otyp].oc_name_known)
+                    ? xname(otmp)
+                    : cloak_simple_name(otmp));
+
+            if (otmp->greased && !rn2(2)) {
+                pline_The("grease wears off.");
+                otmp->greased = 0;
+            }
+            break;
+        }
+
         if (!(otmp = really_steal(otmp, mdef))) /* hero got interrupted... */
             break;
         /* might have dropped otmp, and it might have broken or left level */
-        if (!otmp || otmp->where != OBJ_INVENT)
+        if (!otmp || otmp->where != OBJ_INVENT) {
+            if (as_mon && (gold = findgold(mdef->minvent, TRUE)) != 0)
+                obj_extract_self(gold);
             continue;
+        }
         if (theft_petrifies(otmp))
             break; /* stop thieving even though hero survived */
 
@@ -2625,13 +2651,20 @@ struct attack *mattk;
     if (gold)
         mpickobj(mdef, gold);
 
-    /* Training up thievery skill can be quite the chore, to the point
-       where many players don't bother to use it. Randomly add an
-       additional point of skill for a successful attempt to balance
-       out the drudgery, without having to revamp how skill points are
-       awarded for this specific skill */
-    if (rn2(3)) /* 66% chance in favor of the player */
+    /* only train thievery if you have the skill */
+    if (Role_if(PM_ROGUE) || Role_if(PM_CONVICT)) {
+        /* train the skill here instead of in hmon_hitmon() to avoid premature
+        messages about feeling more dangerous when theft fails */
         use_skill(P_THIEVERY, 1);
+
+        /* Training up thievery skill can be quite the chore, to the point
+        where many players don't bother to use it. Randomly add an
+        additional point of skill for a successful attempt to balance
+        out the drudgery, without having to revamp how skill points are
+        awarded for this specific skill */
+        if (rn2(3)) /* 66% chance in favor of the player */
+            use_skill(P_THIEVERY, 1);
+    }
 }
 
 /* Actual mechanics of stealing obj from mdef. This is now its own function


### PR DESCRIPTION
Currently, even terrible sacrifice gifts like a +3 wooden dagger count towards your total gifts received, making it more difficult to get future gifts, which can be very frustrating. Instead, only count magical gifts. This comprises: artifacts, equipment with object properties, non-blank spellbooks & divine knowledge, and inherently magical equipment (e.g. staff of healing or gauntlets of dexterity).