### PR TITLE
autounlocking & magic chests

### DIFF
--- a/src/lock.c
+++ b/src/lock.c
@@ -374,6 +374,9 @@ boolean opening; /* True: key, pick, or card; False: key or pick */
     /* only resort to other role's quest artifact if no other choice */
     if (!key && !mkey && !pick && !card)
         mkey = amkey;
+    /* rogues favor MKoT for its untrapping */
+    if (is_roguish_key(&youmonst, key) && Role_if(PM_ROGUE))
+        mkey = key;
     if (!key && !pick && !card)
         key = akey;
     if (!pick && !card)

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1768,6 +1768,7 @@ struct obj **cobjp;
 int cindex, ccount; /* index of this container (1..N), number of them (N) */
 {
     struct obj *cobj = *cobjp;
+    struct obj *maybeart;
 
     if (!cobj)
         return 0;
@@ -1792,8 +1793,25 @@ int cindex, ccount; /* index of this container (1..N), number of them (N) */
             case CHEST:
                 unlocktool = autokey(TRUE);
                 break;
+            case HIDDEN_CHEST:
+                unlocktool = autokey(TRUE);
+                if (unlocktool
+                    && (unlocktool->otyp == MAGIC_KEY || unlocktool->oartifact))
+                    break;
+                /* may be you have the MKoT and are cross-aligned */
+                for (maybeart = invent; maybeart;
+                     maybeart = nxtobj(maybeart, SKELETON_KEY, FALSE))
+                    if (maybeart->oartifact)
+                        unlocktool = maybeart;
+                /* may be that you have neither magic key nor MKoT, but you
+                   have a regular key/pick and the PYEC */
+                for (maybeart = invent; maybeart;
+                     maybeart = nxtobj(maybeart, CREDIT_CARD, FALSE))
+                    if (maybeart->oartifact)
+                        unlocktool = maybeart;
+                break;
             default:
-                /* Don't prompt for crystal/magic chest; only special unlocking
+                /* Don't prompt for crystal chest; only artifact unlocking
                  * tools can unlock them, and we don't want to give that away
                  * by suggesting them automatically to the user. */
                 break;


### PR DESCRIPTION
1) Tweak autokey() so rogues will automatically make use of MKoT.
2) Allow players to autounlock magic chests. Possibly either this should be reverted or crystal chests should be made autounlockable for consistency. However, they still have different unlocking requirements so it could be left as is. 