### PR TITLE
Magic chest fixes (and crowning?)

### DIFF
--- a/src/invent.c
+++ b/src/invent.c
@@ -3638,8 +3638,7 @@ boolean picked_some;
         Sprintf(fbuf, "There is %s here.", an(dfeature));
 
     if (!otmp || is_lava(u.ux, u.uy)
-        || ((is_pool(u.ux, u.uy) && !Underwater)
-        || (IS_MAGIC_CHEST(levl[u.ux][u.uy].typ)))) {
+        || ((is_pool(u.ux, u.uy) && !Underwater))) {
         if (dfeature)
             pline1(fbuf);
         read_engr_at(u.ux, u.uy); /* Eric Backus */

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1800,13 +1800,13 @@ int cindex, ccount; /* index of this container (1..N), number of them (N) */
                     break;
                 /* may be you have the MKoT and are cross-aligned */
                 unlocktool = (struct obj *) 0;
-                for (maybeart = invent; maybeart;
+                for (maybeart = nxtobj(invent, SKELETON_KEY, FALSE); maybeart;
                      maybeart = nxtobj(maybeart, SKELETON_KEY, FALSE))
                     if (maybeart->oartifact)
                         unlocktool = maybeart;
                 /* may be that you have neither magic key nor MKoT, but you
                    have a regular key/pick and the PYEC */
-                for (maybeart = invent; maybeart;
+                for (nxtobj(invent, CREDIT_CARD, FALSE); maybeart;
                      maybeart = nxtobj(maybeart, CREDIT_CARD, FALSE))
                     if (maybeart->oartifact)
                         unlocktool = maybeart;


### PR DESCRIPTION
Fixes the knife bug mobileuser mentioned, and another I noticed while testing: nearlooking on a magic chest square only told you a magic chest was there and ignored any items on the square.

Also, I have some code to address the infidel crowning issues which I could add to this PR for convenience, but since it's not a clear-cut bugfix I left it out for now.