### PR TITLE
Let all and only giants wield two-handed weapons in one hand

### DIFF
--- a/include/obj.h
+++ b/include/obj.h
@@ -233,9 +233,10 @@ struct obj {
 
 #define is_wet_towel(o) ((o)->otyp == TOWEL && (o)->spe > 0)
 #define bimanual(otmp) \
-    ((!(Race_if(PM_GIANT)) || (Race_if(PM_GIANT) && is_2h_launcher(otmp))) \
-     && ((otmp->oclass == WEAPON_CLASS || otmp->oclass == TOOL_CLASS)      \
-     && objects[otmp->otyp].oc_bimanual))
+    ((!(maybe_polyd(is_giant(youmonst.data), Race_if(PM_GIANT)))      \
+      || is_2h_launcher(otmp))                                        \
+     && (otmp->oclass == WEAPON_CLASS || otmp->oclass == TOOL_CLASS)  \
+     && objects[otmp->otyp].oc_bimanual)
 #define is_multigen(otmp)                           \
     (otmp->oclass == WEAPON_CLASS                   \
      && objects[otmp->otyp].oc_skill >= -P_SHURIKEN \

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1229,7 +1229,7 @@ int alone;
             if (updateinv)
                 update_inventory();
         } else if ((u.twoweap && (bimanual(uwep) || bimanual(uswapwep)))
-                   || (bimanual(uwep) && uarms)) {
+                   || (bimanual(uwep) && uarms && !is_bracer(uarms))) {
             otmp = bimanual(uwep) ? uwep : uswapwep;
             which = is_sword(otmp) ? "sword" : weapon_descr(otmp);
             if (otmp->quan != 1L)


### PR DESCRIPTION

Giant polyforms can do it regardless of real race, and player giants can't do it when polymorphed into a non-giant. If wielding a 2-hander and polymorphing into an smaller form, untwoweapon if possible; if not, unwield your weapon, unless it's cursed and your shield isn't, in which case, unwear your shield. I tried to avoid unwielding/unwearing cursed objects, but still allowed it if there was no other option, just as polymorphing into a handless creature will drop cursed weapons.