### PR TITLE
Improve #wizgenesis monster race parsing

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1651,7 +1651,7 @@ E int FDECL(max_passive_dmg, (struct monst *, struct monst *));
 E boolean FDECL(same_race, (struct permonst *, struct permonst *));
 E int FDECL(monsndx, (struct permonst *));
 E const char *FDECL(mon_race_name, (unsigned));
-E int FDECL(name_to_mon, (const char *));
+E int FDECL(name_to_mon, (const char *, int *));
 E int FDECL(name_to_monclass, (const char *, int *));
 E int FDECL(gender, (struct monst *));
 E int FDECL(pronoun_gender, (struct monst *, BOOLEAN_P));

--- a/src/attrib.c
+++ b/src/attrib.c
@@ -365,7 +365,7 @@ boolean thrown_weapon; /* thrown weapons are less deadly */
     }
 
     /* suppress killer prefix if it already has one */
-    i = name_to_mon(pkiller);
+    i = name_to_mon(pkiller, (int *) 0);
     if (i >= LOW_PM && (mons[i].geno & G_UNIQ)) {
         kprefix = KILLED_BY;
         if (!type_is_pname(&mons[i]))

--- a/src/mon.c
+++ b/src/mon.c
@@ -5462,7 +5462,7 @@ struct monst *mon;
                 mndx = NON_PM;
                 break;
             }
-            mndx = name_to_mon(buf);
+            mndx = name_to_mon(buf, (int *) 0);
             if (mndx == NON_PM) {
                 /* didn't get a type, so check whether it's a class
                    (single letter or text match with def_monsyms[]) */

--- a/src/mondata.c
+++ b/src/mondata.c
@@ -925,8 +925,9 @@ struct alt_spl {
 
 /* figure out what type of monster a user-supplied string is specifying */
 int
-name_to_mon(in_str)
+name_to_mon(in_str, matchlen)
 const char *in_str;
+int *matchlen;
 {
     /* Be careful.  We must check the entire string in case it was
      * something such as "ettin zombie corpse".  The calling routine
@@ -1052,6 +1053,8 @@ const char *in_str;
         if (m_i_len > len && !strncmpi(mons[i].mname, str, m_i_len)) {
             if (m_i_len == slen) {
                 mntmp = i;
+                if (matchlen)
+                    *matchlen = m_i_len;
                 break; /* exact match */
             } else if (slen > m_i_len
                        && (str[m_i_len] == ' '
@@ -1064,6 +1067,8 @@ const char *in_str;
                            || !strcmpi(&str[m_i_len], "es")
                            || !strncmpi(&str[m_i_len], "es ", 3))) {
                 mntmp = i;
+                if (matchlen)
+                    *matchlen = m_i_len;
                 len = m_i_len;
             }
         }
@@ -1156,7 +1161,7 @@ int *mndx_p;
                 return i;
         }
         /* check individual species names */
-        i = name_to_mon(in_str);
+        i = name_to_mon(in_str, (int *) 0);
         if (i != NON_PM) {
             if (mndx_p)
                 *mndx_p = i;

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -3925,7 +3925,7 @@ struct obj *no_wish;
         || !strcmpi(bp, "globs") || !BSTRCMPI(bp, bp + i - 6, " globs")
         || (p = strstri(bp, "glob of ")) != 0
         || (p = strstri(bp, "globs of ")) != 0) {
-        mntmp = name_to_mon(!p ? bp : (strstri(p, " of ") + 4));
+        mntmp = name_to_mon(!p ? bp : (strstri(p, " of ") + 4), (int *) 0);
         /* if we didn't recognize monster type, pick a valid one at random */
         if (mntmp == NON_PM)
             mntmp = rn1(PM_BLACK_PUDDING - PM_GRAY_OOZE, PM_GRAY_OOZE);
@@ -3962,7 +3962,7 @@ struct obj *no_wish;
                 } else {
                     tmp = tin_variety_txt(p + 7, &tinv);
                     tvariety = tinv;
-                    mntmp = name_to_mon(p + 7 + tmp);
+                    mntmp = name_to_mon(p + 7 + tmp, (int *) 0);
                 }
                 typ = TIN;
                 goto typfnd;
@@ -3992,7 +3992,7 @@ struct obj *no_wish;
 
                 l = 0;
 
-                if ((mntmp = name_to_mon(p + of)) >= LOW_PM) {
+                if ((mntmp = name_to_mon(p + of, (int *) 0)) >= LOW_PM) {
                     *p = 0;
                     p = 0;
                 } else if (!strncmpi((p + of), "fire", l = 4)
@@ -4092,7 +4092,7 @@ struct obj *no_wish;
         && strncmpi(bp, "master key", 10)   /* not the "master" rank */
         && strncmpi(bp, "magenta", 7)) {    /* not the "mage" rank */
         if (mntmp < LOW_PM && strlen(bp) > 2
-            && (mntmp = name_to_mon(bp)) >= LOW_PM) {
+            && (mntmp = name_to_mon(bp, (int *) 0)) >= LOW_PM) {
             int mntmptoo, mntmplen; /* double check for rank title */
             char *obp = bp;
 

--- a/src/options.c
+++ b/src/options.c
@@ -6669,13 +6669,13 @@ struct fruit *replace_fruit;
             || !strncmp(pl_fruit, "partly eaten ", 13)
             || (!strncmp(pl_fruit, "tin of ", 7)
                 && (!strcmp(pl_fruit + 7, "spinach")
-                    || name_to_mon(pl_fruit + 7) >= LOW_PM))
+                    || name_to_mon(pl_fruit + 7, (int *) 0) >= LOW_PM))
             || !strcmp(pl_fruit, "empty tin")
             || (!strcmp(pl_fruit, "glob")
                 || (globpfx > 0 && !strcmp("glob", &pl_fruit[globpfx])))
             || ((str_end_is(pl_fruit, " corpse")
                  || str_end_is(pl_fruit, " egg"))
-                && name_to_mon(pl_fruit) >= LOW_PM)) {
+                && name_to_mon(pl_fruit, (int *) 0) >= LOW_PM)) {
             Strcpy(buf, pl_fruit);
             Strcpy(pl_fruit, "candied ");
             nmcpy(pl_fruit + 8, buf, PL_FSIZ - 8);

--- a/src/pager.c
+++ b/src/pager.c
@@ -1758,7 +1758,7 @@ char *supplemental_name;
             if (!lookat_mon) {
                 pm = (struct permonst *) 0; /* just to be safe */
                 if (!object_not_monster(dbase_str_with_material)) {
-                    int mndx = name_to_mon(dbase_str_with_material);
+                    int mndx = name_to_mon(dbase_str_with_material, (int *) 0);
                     if (mndx != NON_PM) {
                         pm = &mons[mndx];
                     }

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -483,7 +483,7 @@ int psflags;
                 continue;  /* end do-while(--tryct > 0) loop */
             }
             class = 0;
-            mntmp = name_to_mon(buf);
+            mntmp = name_to_mon(buf, (int *) 0);
             if (mntmp < LOW_PM) {
             by_class:
                 class = name_to_monclass(buf, &mntmp);

--- a/src/read.c
+++ b/src/read.c
@@ -2489,7 +2489,7 @@ do_class_genocide()
         }
 
         class = name_to_monclass(buf, (int *) 0);
-        if (class == 0 && (i = name_to_mon(buf)) != NON_PM)
+        if (class == 0 && (i = name_to_mon(buf, (int *) 0)) != NON_PM)
             class = mons[i].mlet;
         immunecnt = gonecnt = goodcnt = 0;
         for (i = LOW_PM; i < NUMMONS; i++) {
@@ -2686,7 +2686,7 @@ int how;
                 return;
             }
 
-            mndx = name_to_mon(buf);
+            mndx = name_to_mon(buf, (int *) 0);
             ptr = &mons[mndx];
 
             /* Liches and the like are immune to genocide until Vecna
@@ -3024,9 +3024,9 @@ create_particular_parse(str, d)
 char *str;
 struct _create_particular_data *d;
 {
-    char *rbufp = (char *) 0, *bufp = str;
+    char *bufp = str;
     char *tmpp;
-    int i, race = NON_PM;
+    int i;
 
     d->monclass = MAXMCLASSES;
     d->which = urole.malenum; /* an arbitrary index into mons[] */
@@ -3087,15 +3087,29 @@ struct _create_particular_data *d;
         d->makehostile = TRUE;
     }
 
-    /* determine if a race was specified for the resulting mon
-       TODO?: currently limited only to player-valid races. */
-    for (i = 0; races[i].adj; i++) {
-        int adjlen = strlen(races[i].adj);
-        if (!strncmpi(bufp, races[i].adj, adjlen)
-            && !strncmpi(bufp + adjlen, " race ", 6)) {
-            rbufp = bufp + adjlen + 6;
-            race = races[i].malenum;
-            break;
+    /* determine if a race was specified for the resulting mon */
+    if (!strncmpi(bufp, "racial ", 7)) {
+        bufp += 7;
+        int adjlen;
+        for (i = 0; races[i].adj; i++) {
+            adjlen = strlen(races[i].adj);
+            if (!strncmpi(bufp, races[i].adj, adjlen)
+                && bufp[adjlen] == ' ') {
+                bufp = bufp + adjlen + 1;
+                d->race = races[i].malenum;
+                break;
+            }
+        }
+        /* if no "real" (hero-valid) race matches, try normal monster name */
+        if (d->race == NON_PM) {
+            int race = name_to_mon(bufp, &adjlen);
+            if (race >= LOW_PM && bufp[adjlen] != '\0') {
+                bufp += adjlen;
+                d->race = race;
+                if (*bufp != ' ')
+                    bufp = index(bufp, ' ');
+                ++bufp;
+            }
         }
     }
     /* decide whether a valid monster was chosen */
@@ -3104,12 +3118,7 @@ struct _create_particular_data *d;
         return TRUE;
     }
 
-    if (race != NON_PM && (d->which = name_to_mon(rbufp)) >= LOW_PM) {
-        d->race = race;
-        return TRUE;
-    }
-
-    d->which = name_to_mon(bufp);
+    d->which = name_to_mon(bufp, (int *) 0);
     if (d->which >= LOW_PM)
         return TRUE; /* got one */
 

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -1775,7 +1775,7 @@ struct mkroom *croom;
                 if (!strcmpi(m->appear_as.str, "random"))
                     mndx = select_newcham_form(mtmp);
                 else
-                    mndx = name_to_mon(m->appear_as.str);
+                    mndx = name_to_mon(m->appear_as.str, (int *) 0);
 
                 if (mndx == NON_PM || (is_vampshifter(mtmp)
                                        && !validvamp(mtmp, &mndx, S_HUMAN))) {

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -701,7 +701,7 @@ nh_timeout()
                 }
                 dealloc_killer(kptr);
 
-                if ((m_idx = name_to_mon(killer.name)) >= LOW_PM) {
+                if ((m_idx = name_to_mon(killer.name, (int *) 0)) >= LOW_PM) {
                     if (type_is_pname(&mons[m_idx])) {
                         killer.format = KILLED_BY;
                     } else if (mons[m_idx].geno & G_UNIQ) {


### PR DESCRIPTION
Change the terminology from "human race caveman" to "racial human
caveman" and make create_particular_parse more efficient (as well as
able to apply races which are invalid for the hero -- since we're
requiring the special terminology anyway, that takes care of the
disambiguation that was a concern in adding that previously).
