### PR TITLE
Miscellaneous. . .improvements?

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -1489,8 +1489,17 @@ docallcmd()
         allowall[0] = ALL_CLASSES;
         allowall[1] = '\0';
         obj = getobj(allowall, "name");
-        if (obj)
-            do_oname(obj);
+        if (obj) {
+            char *tempstr = xname(obj);
+            maybereleaseobuf(tempstr);
+
+            if (!obj->dknown) {
+                You("would never recognize %s later.",
+                    obj->quan > 1L ? "them" : "it");
+            } else {
+                do_oname(obj);
+            }
+        }
         break;
     case 'o': /* name a type of object in inventory */
         obj = getobj(callable, "call");
@@ -1498,7 +1507,8 @@ docallcmd()
             /* behave as if examining it in inventory;
                this might set dknown if it was picked up
                while blind and the hero can now see */
-            (void) xname(obj);
+            char *tempstr = xname(obj);
+            maybereleaseobuf(tempstr);
 
             if (!obj->dknown) {
                 You("would never recognize another one.");

--- a/src/hack.c
+++ b/src/hack.c
@@ -2671,6 +2671,12 @@ boolean pick;
         killer.format = NO_KILLER_PREFIX;
         done(DIED);
     }
+    if (IS_MAGIC_CHEST(levl[u.ux][u.uy].typ) && !Levitation) {
+        if (!Blind)
+            You("see here a magic chest.");
+        else
+            You("feel here a magic chest.");
+    }
  spotdone:
     if (!--inspoteffects) {
         spotterrain = STONE; /* 0 */

--- a/src/mon.c
+++ b/src/mon.c
@@ -2650,11 +2650,13 @@ struct monst *magr, *mdef;
 
     /* elvenkind vs orcs */
     if ((racial_elf(magr) || racial_drow(magr))
-        && racial_orc(mdef))
+        && racial_orc(mdef)
+        && !(nonliving(ma) || nonliving(md)))
         return ALLOW_M | ALLOW_TM;
 
     /* elves vs drow */
-    if (racial_elf(magr) && racial_drow(mdef))
+    if (racial_elf(magr) && racial_drow(mdef)
+        && !(nonliving(ma) || nonliving(md)))
         return ALLOW_M | ALLOW_TM;
 
     /* angels vs demons */

--- a/src/mon.c
+++ b/src/mon.c
@@ -2300,9 +2300,9 @@ struct obj *otmp;
     /* maybe can't take whole stack */
     if (curr_mon_load(mtmp) + newload > max_mon_load(mtmp)) {
         int weightper;
-        /* For parity's with weight()'s accounting for massive corpse weights.
+        /* For parity with weight()'s provision for massive piles of corpses.
          * owt is an int but quan is long, so owt can max out, in theory.
-         * weight() sets owt to maximum for corpses in this case.
+         * weight() sets owt to maximum for corpses in that case.
          * NB: weight() breaks for large quantities (read: billions) of
          * non-corpses, which will render this calculation invalid. It's never
          * going to happen in a real game. If need be, weight() can be fixed.

--- a/src/mon.c
+++ b/src/mon.c
@@ -2297,8 +2297,28 @@ struct obj *otmp;
     if (mdat->mlet == S_NYMPH)
         return (otmp->oclass == ROCK_CLASS) ? 0 : iquan;
 
-    if (curr_mon_load(mtmp) + newload > max_mon_load(mtmp))
-        return 0;
+    /* maybe can't take whole stack */
+    if (curr_mon_load(mtmp) + newload > max_mon_load(mtmp)) {
+        int weightper;
+        /* For parity's with weight()'s accounting for massive corpse weights.
+         * owt is an int but quan is long, so owt can max out, in theory.
+         * weight() sets owt to maximum for corpses in this case.
+         * NB: weight() breaks for large quantities (read: billions) of
+         * non-corpses, which will render this calculation invalid. It's never
+         * going to happen in a real game. If need be, weight() can be fixed.
+         * By someone else.
+         */
+        if (otmp->owt == LARGEST_INT)
+            /* the 24 = 120 / 5 is ratio of densest to lightest material, in case
+             * otmp isn't its base material. We can't access actual densities, so
+             * just assume worst case.
+             */
+            weightper = objects[otmp->otyp].oc_weight * 24;
+        /* the normal case: divide stack weight by quantity, rounding up */
+        else
+            weightper = (int) ((((long) otmp->owt) - 1 + otmp->quan) / otmp->quan);
+        return (max_mon_load(mtmp) - curr_mon_load(mtmp)) / weightper;
+    }
 
     return iquan;
 }


### PR DESCRIPTION
Fix 1) Monsters can pick up partial stacks. No longer can you leave 51 diluted potions of full healing on the ground and expect them to be safe from (most) monsters.

Fix(?) 2) Don't allow naming of objects of unknown appearance---it doesn't seem intended, since the names aren't displayed in inventory, but the names could still be accessed. Probably only affects zen players either way.

Fix(?) 3) The elf/drow/orc hate triangle no longer persists past death. All things come to an end. Pointed out by mobileuser.

Fix(?) 4) Give a message when walking on magic chest square so it feels a little more like an object. Hopefully not permanent. Credit/blame to Loggers_VIII for this idea.

I'm not really sure if half of these are wanted or not. Lemme know if you want me to revert some. Ugh, I'm way to tired to be writing PRs. 