### PR TITLE
Fix: Offhand warning

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -963,7 +963,9 @@ long wp_mask;
                 if (obj == otmp && !on) {
                     glow_warning_effects(otmp);
                     obj->lastwarncnt = 0;
-                } else if (obj->owornmask && has_glow_warning(obj)) {
+                } else if (((obj->owornmask & ~W_SWAPWEP)
+                            || (obj->owornmask && u.twoweap))
+                           && has_glow_warning(obj)) {
                     EWarn_of_mon |= obj->owornmask;
                     context.warntype.obj |= spec_mh(obj);
                 }

--- a/src/worn.c
+++ b/src/worn.c
@@ -64,8 +64,12 @@ long mask;
                 if (oobj && !(oobj->owornmask & wp->w_mask))
                     impossible("Setworn: mask = %ld.", wp->w_mask);
                 if (oobj && (oobj != obj)) {
-                    if (u.twoweap && (oobj->owornmask & (W_WEP | W_SWAPWEP)))
+                    if (u.twoweap && (oobj->owornmask & (W_WEP | W_SWAPWEP))) {
+                        /* required to avoid incorrect untwoweapon() feedback */
                         u.twoweap = 0;
+                        /* required to turn off offhand extrinsics */
+                        untwoweapon();
+                    }
                     oobj->owornmask &= ~wp->w_mask;
                     if (wp->w_mask & ~(W_QUIVER)) {
                         /* leave as "x = x <op> y", here and below, for broken


### PR DESCRIPTION
When having a warning-granting artifact in the alternate weapon slot and wielding a warning-granted artifact, applying a pick-axe caused the offhand weapon to start warning you of stuff, sorta. Actually due to two separate deeper problems that usually aren't apparent because ready_weapon() and similar call other functions that fix everything up. But, wield_tool() didn't call them.