### PR TITLE
Band-aid: Catch crashes from splitobj() caused by can_carry()

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -2297,6 +2297,9 @@ struct obj *otmp;
     if (mdat->mlet == S_NYMPH)
         return (otmp->oclass == ROCK_CLASS) ? 0 : iquan;
 
+    /* monster is already over capacity, somehow (rock mole? leprechaun?)*/
+    if (curr_mon_load(mtmp) > max_mon_load(mtmp))
+        return 0;
     /* maybe can't take whole stack */
     if (curr_mon_load(mtmp) + newload > max_mon_load(mtmp)) {
         int weightper;
@@ -2317,7 +2320,21 @@ struct obj *otmp;
         /* the normal case: divide stack weight by quantity, rounding up */
         else
             weightper = (int) ((((long) otmp->owt) - 1 + otmp->quan) / otmp->quan);
-        return (max_mon_load(mtmp) - curr_mon_load(mtmp)) / weightper;
+        /* maybe possible if something manages to have 0 weight */
+        if (weightper < 1)
+            weightper = 1;
+        iquan = (max_mon_load(mtmp) - curr_mon_load(mtmp)) / weightper;
+        /* to catch splitobj crash. hopefully can be properly fixed in time */
+        if (iquan < 0) {
+            impossible("can_carry tried to take %d objects, each weighing %d",
+                       iquan, weightper);
+            iquan = 0;
+        } else if (iquan > otmp->quan) {
+            impossible("can_carry tried to take %d objects, each weighing %d",
+                       iquan, weightper);
+            iquan = otmp->quan;
+        }
+        return iquan;
     }
 
     return iquan;


### PR DESCRIPTION
Relates to commit 4dde18ca6fda25d0141c9579dc8dc76a997c47c2. elunna discovered a crash relating to can_carry() (https://github.com/elunna/hackem/issues/485), but it's unclear exactly what went wrong. The crash is not automatically recoverable, so until this is figured out, clip the return value of can_carry to sensible values, and throw an impossible() so players will notice when it happens; hopefully this will help diagnose the issue.