### PR TITLE
Fix: Multiple messages for gnomes noticing eggs. 

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -4724,6 +4724,7 @@ struct monst *mtmp;
                         verbalize("Ahhhh!  Eggs!  %s has eggs!!",
                                   (flags.female) ? "She" : "He");
                     monflee(mtmp, d(2, 6) + 10, TRUE, TRUE);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Could happen when you are carrying more than one stack of eggs.