### PR TITLE
Address levelporting past demon lords

### DIFF
--- a/include/dungeon.h
+++ b/include/dungeon.h
@@ -163,6 +163,7 @@ typedef struct branch {
 #define MIGR_SSTAIRS 7      /* dungeon branch */
 #define MIGR_PORTAL 8       /* magic portal */
 #define MIGR_WITH_HERO 9    /* mon: followers; obj: trap door */
+#define MIGR_STALK 10       /* dlords follow if the hero skips their lair */
 #define MIGR_NOBREAK 1024   /* bitmask: don't break on delivery */
 #define MIGR_NOSCATTER 2048 /* don't scatter on delivery */
 #define MIGR_TO_SPECIES 4096 /* migrating to species as they are made */

--- a/src/potion.c
+++ b/src/potion.c
@@ -1676,8 +1676,8 @@ int how;
                                    : obj->cursed ? " a lot" : "");
                 dmg = d(obj->cursed ? 2 : 1, obj->blessed ? 4 : 8);
                 losehp(Maybe_Half_Phys(dmg), "potion of acid", KILLED_BY_AN);
-	    } else {
-		monstseesu(M_SEEN_ACID);
+            } else {
+                monstseesu(M_SEEN_ACID);
             }
             break;
         case POT_HALLUCINATION:
@@ -1826,6 +1826,7 @@ int how;
             break;
         case POT_CONFUSION:
         case POT_BOOZE:
+        case POT_HALLUCINATION:
             if (!resist(mon, POTION_CLASS, 0, NOTELL))
                 mon->mconf = TRUE;
             break;


### PR DESCRIPTION
Make dodging demon lords trickier---they will generate near you if you teleport below their lair. 

Also, make hallucination potions confuse monsters, just like AD_HALU attacks do (mentioned by Umbire yesterday, and super easy to change, so I tacked it on here). 