### PR TITLE
Fix: Shadowblade drain life attack not triggering

### DIFF
--- a/doc/evilhack-changelog.md
+++ b/doc/evilhack-changelog.md
@@ -3289,3 +3289,4 @@ The following changes to date are:
 - Cure sickness spell damage vs zombies scales based on skill in casting
   healing spells
 - Fix: distinguish case for protecting classes from genocide
+- Fix: Shadowblade drain life attack not triggering


### PR DESCRIPTION
Now that Shadowblade is a were-bane, it would return early if not instakilling weres, so the DRLI attack never happened. Add a special case to allow that.

Also, its bonus was applying vs. everything. Make it only apply vs. weres & non--drain-resistant. Change spec_applies so it can handle other weapons with two attack types, if any are ever added. (Technically Angelslayer is such a weapon but any issues are avoided due to its bonuses applying vs. all by design and the AD_FIRE case coming before the instakill case in artifact_hit).

This generalizes spec_applies, but artifact_hit will still not handle new artifacts with two attack types correctly. Maybe spec_dbon_applies could use a bit to flag whether a special (i.e. more than just extra damage due to bane/opposite-alignment) attack should happen?