### PR TITLE
Fix: pets inherited the hero's ability to zombify

### DIFF
--- a/include/hack.h
+++ b/include/hack.h
@@ -447,10 +447,11 @@ enum explosion_types {
 
 /* flags for xkilled() [note: meaning of first bit used to be reversed,
    1 to give message and 0 to suppress] */
-#define XKILL_GIVEMSG   0
-#define XKILL_NOMSG     1
-#define XKILL_NOCORPSE  2
-#define XKILL_NOCONDUCT 4
+#define XKILL_GIVEMSG   0x0
+#define XKILL_NOMSG     0x1
+#define XKILL_NOCORPSE  0x2
+#define XKILL_NOCONDUCT 0x4
+#define XKILL_FROMPET   0x8
 
 /* pline_flags; mask values for custompline()'s first argument */
 /* #define PLINE_ORDINARY 0 */

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -2640,6 +2640,7 @@ msickness:
 #undef oresist_disintegration
 
                 mdef->mhp = 0;
+                zombify = FALSE;
                 if (magr->uexp)
                     mon_xkilled(mdef, (char *) 0, -AD_RBRE);
                 else
@@ -3502,6 +3503,7 @@ struct obj *mwep;
 
  assess_dmg:
     if (damage_mon(magr, tmp, (int) mdattk[i].adtyp)) {
+        zombify = FALSE;
         if (mdef->uexp)
             mon_xkilled(magr, "", (int) mdattk[i].adtyp);
         else

--- a/src/mon.c
+++ b/src/mon.c
@@ -761,12 +761,12 @@ unsigned corpseflags;
             return (struct obj *) 0;
         } else {
             corpstatflags |= CORPSTAT_INIT;
-            if racial_zombie(mtmp)
+            if (racial_zombie(mtmp))
                 corpstatflags |= CORPSTAT_ZOMBIE;
             /* preserve the unique traits of some creatures */
             obj = mkcorpstat(CORPSE, KEEPTRAITS(mtmp) ? mtmp : 0,
                              mdat, x, y, corpstatflags);
-            if racial_zombie(mtmp)
+            if (racial_zombie(mtmp))
                 obj->age -= 100;
             if (burythem) {
                 boolean dealloc;

--- a/src/mon.c
+++ b/src/mon.c
@@ -4051,7 +4051,9 @@ struct monst *mtmp;
 void
 xkilled(mtmp, xkill_flags)
 struct monst *mtmp;
-int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
+int xkill_flags; /* XKILL_GIVEMSG, XKILL_NOMSG, XKILL_NOCORPSE,
+                  * XKILL_NOCONDUCT (maintain pacificst),
+                  * or XKILL_FROMPET (killed by a tame mon, not the hero) */
 {
     int tmp, mndx, x = mtmp->mx, y = mtmp->my;
     struct monst museum = zeromonst;

--- a/src/mon.c
+++ b/src/mon.c
@@ -4001,9 +4001,9 @@ int how;
     disintegested = (how == AD_DGST || how == -AD_RBRE
                      || how == AD_WTHR || how == AD_DISN);
     if (disintegested)
-        xkilled(mdef, XKILL_NOCORPSE);
+        xkilled(mdef, XKILL_NOMSG | XKILL_NOCORPSE | XKILL_FROMPET);
     else
-        xkilled(mdef, XKILL_NOMSG);
+        xkilled(mdef, XKILL_NOMSG | XKILL_FROMPET);
 
     if (be_sad && DEADMONSTER(mdef))
         You("have a sad feeling for a moment, then it passes.");
@@ -4062,7 +4062,8 @@ int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
             burycorpse = FALSE,
             nomsg = (xkill_flags & XKILL_NOMSG) != 0,
             nocorpse = (xkill_flags & XKILL_NOCORPSE) != 0,
-            noconduct = (xkill_flags & XKILL_NOCONDUCT) != 0;
+            noconduct = (xkill_flags & XKILL_NOCONDUCT) != 0,
+            petkill = (xkill_flags & XKILL_FROMPET) != 0;
 
     mtmp->mhp = 0; /* caller will usually have already done this */
     if (!noconduct) /* KMH, conduct */
@@ -4179,9 +4180,15 @@ int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
         }
         /* corpse--none if hero was inside the monster */
         if (!wasinside && corpse_chance(mtmp, (struct monst *) 0, FALSE)) {
-            zombify = (!thrownobj && !stoned && !uwep
-                       && zombie_maker(youmonst.data)
-                       && zombie_form(r_data(mtmp)) != NON_PM);
+            /* for kills by tame monsters, 'zombify' will have been set
+             * already in mhitm.c where the information about the particular
+             * attacking monster, etc, was available; for actual kills by the
+             * hero we can figure it out here */
+            if (!petkill) {
+                zombify = (!thrownobj && !stoned && !uwep
+                           && zombie_maker(youmonst.data)
+                           && zombie_form(r_data(mtmp)) != NON_PM);
+            }
             cadaver = make_corpse(mtmp, burycorpse ? CORPSTAT_BURIED
                                                    : CORPSTAT_NONE);
             zombify = FALSE; /* reset */

--- a/src/mon.c
+++ b/src/mon.c
@@ -4064,8 +4064,8 @@ int xkill_flags; /* XKILL_GIVEMSG, XKILL_NOMSG, XKILL_NOCORPSE,
             burycorpse = FALSE,
             nomsg = (xkill_flags & XKILL_NOMSG) != 0,
             nocorpse = (xkill_flags & XKILL_NOCORPSE) != 0,
-            noconduct = (xkill_flags & XKILL_NOCONDUCT) != 0,
-            petkill = (xkill_flags & XKILL_FROMPET) != 0;
+            petkill = (xkill_flags & XKILL_FROMPET) != 0,
+            noconduct = (petkill || (xkill_flags & XKILL_NOCONDUCT) != 0);
 
     mtmp->mhp = 0; /* caller will usually have already done this */
     if (!noconduct) /* KMH, conduct */


### PR DESCRIPTION
Since pets can grant the hero XP by going through mon_xkilled ->
xkilled, which assessed possible zombification of the killed monster
based on youmonst, etc, a pet dog could end up creating zombies if its
owner was in a state to create zombies herself (due to polymorph, race,
etc).  Add a bit to xkill_flags to prevent this and assess zombification
based on the value of the 'zombify' global set in mhitm.c, as happens
with non-pet mon vs mon control flow that goes through monkilled().
