### PR TITLE
Another crack at the zombie-making issue

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1527,7 +1527,7 @@ E int FDECL(cmap_to_type, (int));
 
 E void NDECL(mon_sanity_check);
 E int FDECL(m_poisongas_ok, (struct monst *));
-E boolean FDECL(zombie_maker, (struct permonst *));
+E boolean FDECL(zombie_maker, (struct monst *));
 E int FDECL(zombie_form, (struct permonst *));
 E void FDECL(become_flayer, (struct monst *));
 E int FDECL(undead_to_corpse, (int));

--- a/include/hack.h
+++ b/include/hack.h
@@ -447,10 +447,11 @@ enum explosion_types {
 
 /* flags for xkilled() [note: meaning of first bit used to be reversed,
    1 to give message and 0 to suppress] */
-#define XKILL_GIVEMSG   0
-#define XKILL_NOMSG     1
-#define XKILL_NOCORPSE  2
-#define XKILL_NOCONDUCT 4
+#define XKILL_GIVEMSG   0x0
+#define XKILL_NOMSG     0x1
+#define XKILL_NOCORPSE  0x2
+#define XKILL_NOCONDUCT 0x4
+#define XKILL_INDIRECT  0x8 /* from exploding summoned sphere */
 
 /* pline_flags; mask values for custompline()'s first argument */
 /* #define PLINE_ORDINARY 0 */

--- a/src/end.c
+++ b/src/end.c
@@ -640,7 +640,7 @@ int how;
         u.ugrave_arise = PM_WRAITH;
     else if (mptr->mlet == S_MUMMY && urace.mummynum != NON_PM)
         u.ugrave_arise = urace.mummynum;
-    else if (zombie_maker(mptr) && urace.zombienum != NON_PM)
+    else if (zombie_maker(mtmp) && urace.zombienum != NON_PM)
         u.ugrave_arise = urace.zombienum;
     /* Vampire Mages can produce more of their kind if
        conditions are just right */

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -2640,6 +2640,7 @@ msickness:
 #undef oresist_disintegration
 
                 mdef->mhp = 0;
+                zombify = FALSE;
                 if (magr->uexp)
                     mon_xkilled(mdef, (char *) 0, -AD_RBRE);
                 else
@@ -3502,6 +3503,7 @@ struct obj *mwep;
 
  assess_dmg:
     if (damage_mon(magr, tmp, (int) mdattk[i].adtyp)) {
+        zombify = FALSE;
         if (mdef->uexp)
             mon_xkilled(magr, "", (int) mdattk[i].adtyp);
         else

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -2723,7 +2723,7 @@ msickness:
             mdef->mhp = 0;
         }
 
-        zombify = !mwep && zombie_maker(r_data(magr))
+        zombify = !mwep && zombie_maker(magr)
             && can_become_zombie(r_data(mdef))
             && ((mattk->aatyp == AT_TUCH
                  || mattk->aatyp == AT_CLAW

--- a/src/mon.c
+++ b/src/mon.c
@@ -761,12 +761,12 @@ unsigned corpseflags;
             return (struct obj *) 0;
         } else {
             corpstatflags |= CORPSTAT_INIT;
-            if racial_zombie(mtmp)
+            if (racial_zombie(mtmp))
                 corpstatflags |= CORPSTAT_ZOMBIE;
             /* preserve the unique traits of some creatures */
             obj = mkcorpstat(CORPSE, KEEPTRAITS(mtmp) ? mtmp : 0,
                              mdat, x, y, corpstatflags);
-            if racial_zombie(mtmp)
+            if (racial_zombie(mtmp))
                 obj->age -= 100;
             if (burythem) {
                 boolean dealloc;

--- a/src/mon.c
+++ b/src/mon.c
@@ -4001,9 +4001,9 @@ int how;
     disintegested = (how == AD_DGST || how == -AD_RBRE
                      || how == AD_WTHR || how == AD_DISN);
     if (disintegested)
-        xkilled(mdef, XKILL_NOCORPSE);
+        xkilled(mdef, XKILL_NOMSG | XKILL_NOCORPSE | XKILL_INDIRECT);
     else
-        xkilled(mdef, XKILL_NOMSG);
+        xkilled(mdef, XKILL_NOMSG | XKILL_INDIRECT);
 
     if (be_sad && DEADMONSTER(mdef))
         You("have a sad feeling for a moment, then it passes.");
@@ -4062,7 +4062,8 @@ int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
             burycorpse = FALSE,
             nomsg = (xkill_flags & XKILL_NOMSG) != 0,
             nocorpse = (xkill_flags & XKILL_NOCORPSE) != 0,
-            noconduct = (xkill_flags & XKILL_NOCONDUCT) != 0;
+            noconduct = (xkill_flags & XKILL_NOCONDUCT) != 0,
+            indirect = (xkill_flags & XKILL_INDIRECT) != 0;
 
     mtmp->mhp = 0; /* caller will usually have already done this */
     if (!noconduct) /* KMH, conduct */
@@ -4179,9 +4180,16 @@ int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
         }
         /* corpse--none if hero was inside the monster */
         if (!wasinside && corpse_chance(mtmp, (struct monst *) 0, FALSE)) {
-            zombify = (!thrownobj && !stoned && !uwep
-                       && zombie_maker(youmonst.data)
-                       && zombie_form(r_data(mtmp)) != NON_PM);
+            /* for kills by monsters credited to the hero (e.g. summoned
+             * exploding spheres), zombify will have been set already in
+             * mhitm.c where the information about the particular attacking
+             * monster, etc, was available; for actual kills by the hero we
+             * can figure it out here */
+            if (!indirect) {
+                zombify = (!thrownobj && !stoned && !uwep
+                           && zombie_maker(youmonst.data)
+                           && zombie_form(r_data(mtmp)) != NON_PM);
+            }
             cadaver = make_corpse(mtmp, burycorpse ? CORPSTAT_BURIED
                                                    : CORPSTAT_NONE);
             zombify = FALSE; /* reset */

--- a/src/mon.c
+++ b/src/mon.c
@@ -230,19 +230,13 @@ struct monst *mtmp;
 /* Return TRUE if this monster is capable of converting other monsters into
  * zombies. */
 boolean
-zombie_maker(pm)
-struct permonst * pm;
+zombie_maker(mon)
+struct monst *mon;
 {
-    switch(pm->mlet) {
-    case S_ZOMBIE:
-        /* Z-class monsters that aren't actually zombies go here */
-        return is_zombie(pm);
-    }
-
-    if (!Upolyd && Race_if(PM_DRAUGR))
-        return TRUE;
-
-    return FALSE;
+    /* NB: right now, this is literally just a wrapper around racial_zombie,
+     * but maybe in the future there will be more complicated rules or
+     * exceptions about when zombies will be created -- esp. by the hero */
+    return racial_zombie(mon);
 }
 
 /* From xNetHack: return the monster index of the zombie monster which this monster could be
@@ -4189,7 +4183,7 @@ int xkill_flags; /* XKILL_GIVEMSG, XKILL_NOMSG, XKILL_NOCORPSE,
              * can figure it out here */
             if (!indirect) {
                 zombify = (!thrownobj && !stoned && !uwep
-                           && zombie_maker(youmonst.data)
+                           && zombie_maker(&youmonst)
                            && zombie_form(r_data(mtmp)) != NON_PM);
             }
             cadaver = make_corpse(mtmp, burycorpse ? CORPSTAT_BURIED

--- a/src/mon.c
+++ b/src/mon.c
@@ -4051,7 +4051,9 @@ struct monst *mtmp;
 void
 xkilled(mtmp, xkill_flags)
 struct monst *mtmp;
-int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
+int xkill_flags; /* XKILL_GIVEMSG, XKILL_NOMSG, XKILL_NOCORPSE,
+                  * XKILL_NOCONDUCT (maintain pacificst),
+                  * or XKILL_INDIRECT (mtmp killed by summoned sphere) */
 {
     int tmp, mndx, x = mtmp->mx, y = mtmp->my;
     struct monst museum = zeromonst;


### PR DESCRIPTION
Cf. #176, an abortive attempt to handle the same issue (that pets -- and maybe
other, non-tame monsters too? -- seemed to be able to inappropriately create
zombies when the hero was a draugr).

- Fix: summoned spheres could zombify victims
- Fix: if statement syntax typo
- Update xkill_flags comment
- Fix: zombie_maker and hero or monster race
