### PR TITLE
Backport DPI awareness fix from Nethack/Nethack 1cb0260b1

### DIFF
--- a/sys/winnt/win10.c
+++ b/sys/winnt/win10.c
@@ -9,6 +9,7 @@
 #include "hack.h"
 
 typedef DPI_AWARENESS_CONTEXT(WINAPI *GetThreadDpiAwarenessContextProc)(VOID);
+typedef DPI_AWARENESS_CONTEXT(WINAPI *SetThreadDpiAwarenessContextProc)(DPI_AWARENESS_CONTEXT);
 typedef BOOL(WINAPI *AreDpiAwarenessContextsEqualProc)(
     DPI_AWARENESS_CONTEXT dpiContextA, DPI_AWARENESS_CONTEXT dpiContextB);
 typedef UINT(WINAPI *GetDpiForWindowProc)(HWND hwnd);
@@ -18,6 +19,7 @@ typedef LONG (WINAPI *GetCurrentPackageFullNameProc)(UINT32 *packageFullNameLeng
 typedef struct {
     BOOL Valid;
     GetThreadDpiAwarenessContextProc GetThreadDpiAwarenessContext;
+    SetThreadDpiAwarenessContextProc SetThreadDpiAwarenessContext;
     AreDpiAwarenessContextsEqualProc AreDpiAwarenessContextsEqual;
     GetDpiForWindowProc GetDpiForWindow;
     GetCurrentPackageFullNameProc GetCurrentPackageFullName;
@@ -33,6 +35,10 @@ void win10_init()
 
         if (hUser32 == NULL) 
             panic("Unable to load user32.dll");
+
+        gWin10.SetThreadDpiAwarenessContext = (SetThreadDpiAwarenessContextProc) GetProcAddress(hUser32, "SetThreadDpiAwarenessContext");
+        if (gWin10.SetThreadDpiAwarenessContext == NULL)
+            panic("Unable to get address of SetThreadDpiAwarenessContext()");
 
         gWin10.GetThreadDpiAwarenessContext = (GetThreadDpiAwarenessContextProc) GetProcAddress(hUser32, "GetThreadDpiAwarenessContext");
         if (gWin10.GetThreadDpiAwarenessContext == NULL)
@@ -63,6 +69,10 @@ void win10_init()
     }
 
     if (gWin10.Valid) {
+        if (!gWin10.SetThreadDpiAwarenessContext(
+                DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2))
+            panic("Unable to set DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2");
+
         if (!gWin10.AreDpiAwarenessContextsEqual(
                 gWin10.GetThreadDpiAwarenessContext(),
                 DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2))


### PR DESCRIPTION
Specifically https://github.com/NetHack/NetHack/commit/1cb0260b1c61a959d6ad4a0b9847aa58b59980b6 .

I was running into this on Windows 11 when trying to override the DPI for this application. Unfortunately I'm having some compiler problems and haven't been able to test this, so feel free to close this if you don't want the fix.