### PR TITLE
fix: eight separate calls to strcpy() and strcat() i... in vmsmail.c

### DIFF
--- a/sys/vms/vmsmail.c
+++ b/sys/vms/vmsmail.c
@@ -132,7 +132,7 @@ char *buf;        /* input: filtered broadcast text */
         !strncmpi(q = buf, "mail ", 5)) {   /* unexpected alternative */
         typ = MSG_MAIL;
         p = strstri(q, " from");
-        txt = p ? strcat(strcpy(txt_buf, "Mail for you"), p) : (char *) 0;
+        txt = p ? (snprintf(txt_buf, sizeof txt_buf, "Mail for you%s", p), txt_buf) : (char *) 0;
 
         if (!strncmpi(buf, "new mail", 8)) {
             /*
@@ -163,8 +163,10 @@ char *buf;        /* input: filtered broadcast text */
              */
             nam = "STmail";
             cmd = "MSG";
-            if (txt && (p = strstri(p, " in ")) != 0) /* specific folder */
-                cmd = strcat(strcpy(cmd_buf, "MSG +"), p + 4);
+            if (txt && (p = strstri(p, " in ")) != 0) { /* specific folder */
+                snprintf(cmd_buf, sizeof cmd_buf, "MSG +%s", p + 4);
+                cmd = cmd_buf;
+            }
         } else if (q - 2 >= buf && !strncmpi(q - 2, "mm", 2)) {
             /*
              * {MultiNet\ |PMDF\/}MM mail has arrived on FOO from BAR\n
@@ -191,8 +193,10 @@ char *buf;        /* input: filtered broadcast text */
             txt = (char *) 0; /* don't rely on "from" info here */
         }
 
-        if (!txt)
-            txt = strcat(strcpy(txt_buf, "Mail for you: "), buf);
+        if (!txt) {
+            snprintf(txt_buf, sizeof txt_buf, "Mail for you: %s", buf);
+            txt = txt_buf;
+        }
 
     /*
      * end of mail recognition; now check for call-type interruptions...
@@ -206,7 +210,8 @@ char *buf;        /* input: filtered broadcast text */
         cmd = "PHONE ANSWER";
         if (!strncmpi(q + 8, " you", 4))
             q += (8 + 4), *q = '\0';
-        txt = strcat(strcpy(txt_buf, "Do you hear ringing?  "), buf);
+        snprintf(txt_buf, sizeof txt_buf, "Do you hear ringing?  %s", buf);
+        txt = txt_buf;
     } else if ((q = strstri(buf, " talk-daemon")) != 0
                || (q = strstri(buf, " talk_daemon")) != 0) {
         /*
@@ -218,7 +223,8 @@ char *buf;        /* input: filtered broadcast text */
         nam = "Talk request"; /* MultiNet's TALK and/or TALK/OLD */
         cmd = "TALK";
         if ((p = strstri(q, " by ")) != 0) {
-            txt = strcat(strcpy(txt_buf, "Talk request from"), p + 3);
+            snprintf(txt_buf, sizeof txt_buf, "Talk request from%s", p + 3);
+            txt = txt_buf;
             if ((p = strstri(p, "respond with")) != 0) {
                 if (*(p - 1) == '[')
                     *(p - 1) = '\0';
@@ -229,13 +235,16 @@ char *buf;        /* input: filtered broadcast text */
                     p++;
                 if (*p == ' ')
                     p++;
-                cmd = strcpy(cmd_buf, p); /* "TALK[/OLD] bar@spam" */
+                snprintf(cmd_buf, sizeof cmd_buf, "%s", p); /* "TALK[/OLD] bar@spam" */
+                cmd = cmd_buf;
                 p = eos(cmd_buf);
                 if (*--p == ']')
                     *p = '\0';
             }
-        } else
-            txt = strcat(strcpy(txt_buf, "Pardon the interruption: "), buf);
+        } else {
+            snprintf(txt_buf, sizeof txt_buf, "Pardon the interruption: %s", buf);
+            txt = txt_buf;
+        }
     } else if (is_jnet_send) { /* sscanf(,"(%[^)])%s -%c",,,)==3 */
     jnet_send:
         /*
@@ -263,7 +272,8 @@ char *buf;        /* input: filtered broadcast text */
         typ = MSG_OTHER;
         nam = (char *) 0; /*"captured broadcast message"*/
         cmd = (char *) 0;
-        txt = strcat(strcpy(txt_buf, "Message for you: "), buf);
+        snprintf(txt_buf, sizeof txt_buf, "Message for you: %s", buf);
+        txt = txt_buf;
 #ifdef SHELL
     }
     /* Daemon in newmail() will append period when the text is displayed */
@@ -273,12 +283,10 @@ char *buf;        /* input: filtered broadcast text */
     /* newmail() and readmail() used to assume that nam and cmd are
        concatenated but that is no longer the case */
     if (nam && nam != nam_buf) {
-        (void) strncpy(nam_buf, nam, sizeof nam_buf - 1);
-        nam_buf[sizeof nam_buf - 1] = '\0';
+        snprintf(nam_buf, sizeof nam_buf, "%s", nam);
     }
     if (cmd && cmd != cmd_buf) {
-        (void) strncpy(cmd_buf, cmd, sizeof cmd_buf - 1);
-        cmd_buf[sizeof cmd_buf - 1] = '\0';
+        snprintf(cmd_buf, sizeof cmd_buf, "%s", cmd);
     }
 #endif /* SHELL */
     /* truncate really long messages to prevent verbalize() from blowing up */
@@ -518,7 +526,7 @@ main()
     for (;;) {
         ckmailstatus();
         printf("> "), fflush(stdout); /* issue a prompt */
-        if (!gets(dummy))
+        if (!fgets(dummy, sizeof dummy, stdin))
             break; /* wait for a response */
     }
     disable_broadcast_trapping();
@@ -548,7 +556,7 @@ wait_synch()
 
     printf("\nPress <return> to continue: ");
     fflush(stdout);
-    (void) gets(dummy);
+    (void) fgets(dummy, sizeof dummy, stdin);
 }
 #endif /* TEST_DRIVER */
 

--- a/sys/vms/vmsmail.c
+++ b/sys/vms/vmsmail.c
@@ -252,10 +252,10 @@ char *buf;        /* input: filtered broadcast text */
          */
         typ = MSG_CALL;
         nam = "Bitnet noise"; /* RSCS/NJE message received via JNET */
-        Sprintf(cmd_buf, "XYZZY %s@%s", user, node);
+        snprintf(cmd_buf, sizeof cmd_buf, "XYZZY %s@%s", user, node);
         cmd = cmd_buf;
         /*{ perhaps just vanilla SEND instead of XYZZY? }*/
-        Sprintf(txt_buf, "Message from %s@%s:%s", user, node,
+        snprintf(txt_buf, sizeof txt_buf, "Message from %s@%s:%s", user, node,
                 /* "(node)user -" */
                 &buf[1 + strlen(node) + 1 + strlen(user) + 2 - 1]);
         txt = txt_buf;


### PR DESCRIPTION
## Summary

Replace several unbounded string copies in the OpenVMS mail/broadcast parser with bounded formatting.

## Details

`sys/vms/vmsmail.c` builds display text and response commands from captured VMS mail, phone, talk, and broadcast messages using fixed-size buffers (`txt_buf`, `cmd_buf`, and `nam_buf`). Some paths used `strcpy()`/`strcat()` to append message-derived text into those buffers.

Although broadcast input is already bounded, prefixes such as `"Mail for you: "` or `"MSG +"` can cause the constructed output to exceed the destination buffer. This patch uses `snprintf()` consistently so long messages are truncated safely.

The test-driver-only `gets()` calls are also replaced with `fgets()`.

## Security impact

This is defensive memory-safety hardening for VMS-specific mail/broadcast handling. Exploitability depends on VMS build configuration and whether an attacker can deliver crafted broadcast/mail/talk text to a running game process.

## Changes

- Replace unbounded `strcpy()`/`strcat()` constructions with `snprintf()`
- Replace test-driver `gets()` calls with `fgets()`
- Preserve existing parser behavior while truncating oversized constructed strings safely

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
